### PR TITLE
fix level0 regex typo: \? -> ?

### DIFF
--- a/run_cli.py
+++ b/run_cli.py
@@ -8,7 +8,7 @@ if __name__ == '__main__':
     parser.add_argument('--offset', type=int, default=0,
                         help='Page offset of contents')
     parser.add_argument('--l0', type=str,
-                        default=r'^\d+\.\s\?',
+                        default=r'^\d+\.\s?',
                         help='Regular expression of level 0 of content')
     parser.add_argument('--l1', type=str,
                         default=r'^\d+\.\d+\w?\s?',

--- a/src/gui/main_ui.py
+++ b/src/gui/main_ui.py
@@ -241,7 +241,7 @@ class Ui_PDFdir(object):
         self.offset_edit.setText(_translate("PDFdir", "0"))
         self.sub_dir_group.setTitle(_translate("PDFdir", "目录分层"))
         self.level0_box.setText(_translate("PDFdir", "首层"))
-        self.level0_edit.setText(_translate("PDFdir", "^\\d+\\.\\s\\?"))
+        self.level0_edit.setText(_translate("PDFdir", "^\\d+\\.\\s?"))
         self.level1_box.setText(_translate("PDFdir", "二层"))
         self.level1_edit.setText(_translate("PDFdir", "^\\d+\\.\\d+\\w?\\s?"))
         self.level2_box.setText(_translate("PDFdir", "三层"))

--- a/src/gui/main_ui.ui
+++ b/src/gui/main_ui.ui
@@ -195,7 +195,7 @@ p, li { white-space: pre-wrap; }
             </size>
            </property>
            <property name="text">
-            <string extracomment="可变部分用*代替，如“第*部分”">^\d+\.\s\?</string>
+            <string extracomment="可变部分用*代替，如“第*部分”">^\d+\.\s?</string>
            </property>
            <property name="echoMode">
             <enum>QLineEdit::Normal</enum>


### PR DESCRIPTION
个人感觉最高层的正则表达式 `^\d+\.\s\?` 有问题？

感觉末尾的 `\?` 似乎是应该是`?` （无反斜杠）

翻了下代码，发现层级匹配的循环顺序，是由小层级到大层级。所以目前一般使用情形下程序没引发出此 typo 造成的 bug

（又或者难道这其实是 feature）