### PR TITLE
Fixed: Preserve metadata of source PDF

### DIFF
--- a/src/pdf/pdf.py
+++ b/src/pdf/pdf.py
@@ -100,6 +100,8 @@ class Pdf(object):
                 )
                 new_writer = copy.deepcopy(writer)
                 new_writer.append_pages_from_reader(reader)
+        if reader.metadata is not None:
+            new_writer.add_metadata(reader.metadata)
         return new_writer
 
     @staticmethod


### PR DESCRIPTION
此 PR 修复了如下的问题

## 问题描述

原 PDF 中的元数据（如创建者、创建日期、修改时间、创建者所用的程序等）在 pdfdir 输出的 PDF 会丢失

## 复现

样例文件 [Binder2.pdf](https://github.com/user-attachments/files/23688039/Binder2.pdf)

注意原 PDF 中是有元数据的。使用 Chrome 打开 PDF，并查看元数据，如下图所示

<img width="925" height="973" alt="image" src="https://github.com/user-attachments/assets/bb766329-ba38-4153-8357-afbf3f4823d2" />



添加书签。随便什么书签都可以。这里为了方便测试，贴一下我做的书签
```
0. Abstract  1
1. Introduction  4
2. Goals  7
3. Goals of This Document  8
4. Presentation Language  9
5. HMAC and the Pseudorandom Function  16
6. The TLS Record Protocol  17
7. The TLS Handshaking Protocols  28
8. Cryptographic Computations  64
9. Mandatory Cipher Suites  65
10. Application Data Protocol  66
11. Security Considerations  67
12. IANA Considerations  68
Appendix A. Protocol Data Structures and Constant Values  70
Appendix B. Glossary  76
Appendix C. Cipher Suite Definitions  79
Appendix D. Implementation Notes  81
Appendix E. Backward Compatibility  83
Appendix F. Security Analysis  87
```

输出的 PDF 中，元数据已经丢失，如图所示：
<img width="901" height="956" alt="image" src="https://github.com/user-attachments/assets/8ad17ff9-626f-4a7f-87bd-b5ae0cbd5dc0" />


这个 PR 修复了此问题。

