### PR TITLE
Add automatic page offset inference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,9 +32,9 @@ Windows/macOS/Ubuntu:
 ### 基本用法
 
 + 选择文件：在 "PDF文件路径" 文本框中填入pdf文件路径（如D:/统计思维.pdf）或点击 "打开" 按钮通过文件管理器选择所需的pdf文件。
-+ 目录文本：将目录文本粘贴到“目录文本”框中。[如何获取目录文本](#获取目录文本)。
++ 目录文本：将目录文本粘贴到“目录文本”框中。[如何获取目录文本](#获取目录文本)。对于已有目录页的文字版或扫描版 PDF，也可以点击“自动读取目录”从 PDF 前部目录页中识别并填充目录文本。
 + 编辑写入目录（可选项）：根据目录文本自动生成的实际写入目录，可双击任一目录或页数进行编辑。同时支持拖动改变顺序/目录上下级关系。
-+ 编辑页数增加（可选项）：
++ 编辑页差（可选项）：当目录中的标注页码与 PDF 实际页数不一致时，可在“页差”中填写差值，程序会在预览中换算出实际页数。也可以点击“自动填充页差”根据目录标题在 PDF 中的位置自动推断页差；文字版 PDF 可直接使用，扫描版 PDF 需要安装 OCR 可选依赖。
 + 写入：点击右下角的“写入”按钮，稍等片刻，待状态栏提示"******* Finished!"表示写入成功，此时可在pdf目录下找到包含书签的 *原文件名\_new.pdf* 文件。
 
 ###  获取目录文本
@@ -96,6 +96,12 @@ https://www.python.org/downloads/
 `pip install -r requirements.txt`
 
 `pip install PyQt5`
+
+如需为扫描版 PDF 自动读取目录或自动填充页差，还需要安装 OCR 可选依赖，并执行：
+
+`pip install -r requirements_ocr.txt`
+
+自动读取目录会优先使用 PaddleOCR 识别中文目录页；如果 PaddleOCR 不可用，会回退到 Tesseract OCR。自动填充页差仍使用 Tesseract OCR。
 
 若提示`No matching distribution found for pyqt5` 可参照[PyQt官方文档](http://pyqt.sourceforge.net/Docs/PyQt5/installation.html)进行安装。
 

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,7 @@ https://www.python.org/downloads/
 `pip install -r requirements_ocr.txt`
 
 自动读取目录会优先使用 PaddleOCR 识别中文目录页；如果 PaddleOCR 不可用，会回退到 Tesseract OCR。自动填充页差仍使用 Tesseract OCR。
+使用 Tesseract 回退前，还需单独安装 Tesseract 程序及 `chi_sim`、`eng` 语言数据。
 
 若提示`No matching distribution found for pyqt5` 可参照[PyQt官方文档](http://pyqt.sourceforge.net/Docs/PyQt5/installation.html)进行安装。
 
@@ -176,4 +177,3 @@ options:
 
 + \*, \+ 符号会匹配尽可能多的内容，比如如果用"第\w\*章" 来匹配，"第一节如何阅读此章"这段内容也会被匹配到，更好的写法是确定要匹配内容的长度，写成"第\w{1,2}章"。
 + 要匹配一个不是正则表达式中的正常字符直接写即可，如"第", "1", 甚至包括空格。但正则表达式中有定义用于匹配的一些特殊字符如果要作为普通字符匹配，则要在前面加一个"\\"，比如匹配"1.1"这种格式，可以写成"\d\\.\d"。"\\"符号本身也要如此。
-

--- a/requirements_ocr.txt
+++ b/requirements_ocr.txt
@@ -1,0 +1,5 @@
+PyMuPDF~=1.24.0
+Pillow~=10.0
+paddleocr>=2.7
+paddlepaddle>=2.6
+pytesseract~=0.3.10

--- a/requirements_ocr.txt
+++ b/requirements_ocr.txt
@@ -1,5 +1,5 @@
 PyMuPDF~=1.24.0
 Pillow~=10.0
-paddleocr>=2.7
-paddlepaddle>=2.6
+paddleocr>=2.7,<4
+paddlepaddle>=2.6,<4
 pytesseract~=0.3.10

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -421,7 +421,7 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
 
     def fill_offset(self):
         if self._worker_thread and self._worker_thread.isRunning():
-            self.alert_msg("Page offset inference is already running", level="warn")
+            self.alert_msg("A background task is already running", level="warn")
             return
         if not self.pdf_path:
             self.alert_msg("Please select PDF first", level="warn")

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -21,6 +21,8 @@ from src.gui.base import TreeWidget
 from src.gui.main_ui import Ui_PDFdir
 from src.updater import is_updated
 from src.pdf.bookmark import add_bookmark, check_bookmarks, get_bookmarks
+from src.pdf.page_offset import infer_page_offset
+from src.pdf.toc import extract_toc_text
 
 # import qdarkstyle
 
@@ -34,6 +36,54 @@ class ControlButtonMixin(object):
     def set_control_button(self, min_button, exit_button):
         min_button.clicked.connect(self.showMinimized)
         exit_button.clicked.connect(self.close)
+
+
+class PageOffsetWorker(QtCore.QObject):
+    finished = QtCore.pyqtSignal(object)
+    failed = QtCore.pyqtSignal(str)
+    progress = QtCore.pyqtSignal(int, int)
+
+    def __init__(self, pdf_path, dir_text):
+        super(PageOffsetWorker, self).__init__()
+        self.pdf_path = pdf_path
+        self.dir_text = dir_text
+
+    @QtCore.pyqtSlot()
+    def run(self):
+        try:
+            offset = infer_page_offset(
+                self.pdf_path,
+                self.dir_text,
+                use_ocr=True,
+                progress_callback=self.progress.emit,
+            )
+        except Exception as e:
+            self.failed.emit(str(e))
+        else:
+            self.finished.emit(offset)
+
+
+class TocTextWorker(QtCore.QObject):
+    finished = QtCore.pyqtSignal(str)
+    failed = QtCore.pyqtSignal(str)
+    progress = QtCore.pyqtSignal(int, int)
+
+    def __init__(self, pdf_path):
+        super(TocTextWorker, self).__init__()
+        self.pdf_path = pdf_path
+
+    @QtCore.pyqtSlot()
+    def run(self):
+        try:
+            toc_text = extract_toc_text(
+                self.pdf_path,
+                use_ocr=True,
+                progress_callback=self.progress.emit,
+            )
+        except Exception as e:
+            self.failed.emit(str(e))
+        else:
+            self.finished.emit(toc_text)
 
 
 class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
@@ -50,6 +100,8 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self.app = app
         self.trans = trans
         self.setupUi(self)
+        self._init_auto_offset_button()
+        self._init_auto_toc_button()
         self._fix_small_fonts()
         self.version = CONFIG.VERSION
         self.default_folder = CONFIG.DEFAULT_FOLDER
@@ -66,6 +118,7 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self._set_action()
         self._set_unwritable()
         self._worker = None
+        self._worker_thread = None
 
     def _fix_small_fonts(self):
         """Override hardcoded small font sizes from main_ui.py for readability.
@@ -96,9 +149,27 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
                 if isinstance(widget, QtWidgets.QTextEdit):
                     widget.setStyleSheet("QTextEdit { font-size: " + str(min_size) + "pt; }")
 
+    def _init_auto_offset_button(self):
+        self.auto_offset_button = QtWidgets.QPushButton(self.main_widget)
+        self.auto_offset_button.setObjectName("auto_offset_button")
+        self.auto_offset_button.setText("自动填充页差")
+        self.verticalLayout_3.insertWidget(
+            self.verticalLayout_3.indexOf(self.sub_dir_group), self.auto_offset_button
+        )
+
+    def _init_auto_toc_button(self):
+        self.auto_toc_button = QtWidgets.QPushButton(self.main_widget)
+        self.auto_toc_button.setObjectName("auto_toc_button")
+        self.auto_toc_button.setText("自动读取目录")
+        self.verticalLayout_3.insertWidget(
+            self.verticalLayout_3.indexOf(self.sub_dir_group), self.auto_toc_button
+        )
+
     def _set_connect(self):
         self.open_button.clicked.connect(self.open_file_dialog)
         self.export_button.clicked.connect(self.write_tree_to_pdf)
+        self.auto_offset_button.clicked.connect(self.fill_offset)
+        self.auto_toc_button.clicked.connect(self.fill_toc_text)
         self.level0_box.clicked.connect(self._change_level0_writable)
         self.level1_box.clicked.connect(self._change_level1_writable)
         self.level2_box.clicked.connect(self._change_level2_writable)
@@ -338,6 +409,104 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
                     inserted_items[k] = tree_item
         for item in inserted_items.values():
             item.setExpanded(1)
+
+    def fill_offset(self):
+        if self._worker_thread and self._worker_thread.isRunning():
+            self.alert_msg("Page offset inference is already running", level="warn")
+            return
+        if not self.pdf_path:
+            self.alert_msg("Please select PDF first", level="warn")
+            return
+        if not self.dir_text.strip():
+            self.alert_msg("Please input directory text first", level="warn")
+            return
+
+        self.auto_offset_button.setEnabled(False)
+        self.show_status("Inferring page offset, OCR may take a while...")
+
+        self._worker_thread = QtCore.QThread(self)
+        self._worker = PageOffsetWorker(self.pdf_path, self.dir_text)
+        self._worker.moveToThread(self._worker_thread)
+        self._worker_thread.started.connect(self._worker.run)
+        self._worker.finished.connect(self._offset_inferred)
+        self._worker.failed.connect(self._offset_failed)
+        self._worker.progress.connect(self._offset_progress)
+        self._worker.finished.connect(self._worker_thread.quit)
+        self._worker.failed.connect(self._worker_thread.quit)
+        self._worker.finished.connect(self._worker.deleteLater)
+        self._worker.failed.connect(self._worker.deleteLater)
+        self._worker_thread.finished.connect(self._worker_thread.deleteLater)
+        self._worker_thread.finished.connect(self._offset_worker_finished)
+        self._worker_thread.start()
+
+    def fill_toc_text(self):
+        if self._worker_thread and self._worker_thread.isRunning():
+            self.alert_msg("A background task is already running", level="warn")
+            return
+        if not self.pdf_path:
+            self.alert_msg("Please select PDF first", level="warn")
+            return
+
+        self.auto_toc_button.setEnabled(False)
+        self.show_status("Reading table of contents, OCR may take a while...")
+
+        self._worker_thread = QtCore.QThread(self)
+        self._worker = TocTextWorker(self.pdf_path)
+        self._worker.moveToThread(self._worker_thread)
+        self._worker_thread.started.connect(self._worker.run)
+        self._worker.finished.connect(self._toc_text_inferred)
+        self._worker.failed.connect(self._toc_text_failed)
+        self._worker.progress.connect(self._toc_progress)
+        self._worker.finished.connect(self._worker_thread.quit)
+        self._worker.failed.connect(self._worker_thread.quit)
+        self._worker.finished.connect(self._worker.deleteLater)
+        self._worker.failed.connect(self._worker.deleteLater)
+        self._worker_thread.finished.connect(self._worker_thread.deleteLater)
+        self._worker_thread.finished.connect(self._toc_worker_finished)
+        self._worker_thread.start()
+
+    def _offset_inferred(self, offset):
+        if offset is None:
+            self.alert_msg("Could not infer page offset", level="warn")
+            return
+        display_offset = offset - 1
+        self.offset_edit.setText(str(display_offset))
+        self.show_status(
+            "Page offset inferred: {}".format(display_offset), 3000
+        )
+
+    def _offset_failed(self, message):
+        self.alert_msg("Infer page offset failed: {}".format(message), level="warn")
+
+    def _offset_progress(self, current, total):
+        self.show_status(
+            "Inferring page offset with OCR: {}/{} pages".format(current, total)
+        )
+
+    def _offset_worker_finished(self):
+        self.auto_offset_button.setEnabled(True)
+        self._worker = None
+        self._worker_thread = None
+
+    def _toc_text_inferred(self, toc_text):
+        if not toc_text:
+            self.alert_msg("Could not read table of contents", level="warn")
+            return
+        self.dir_text_edit.setPlainText(toc_text)
+        self.show_status("Table of contents loaded", 3000)
+
+    def _toc_text_failed(self, message):
+        self.alert_msg("Read table of contents failed: {}".format(message), level="warn")
+
+    def _toc_progress(self, current, total):
+        self.show_status(
+            "Reading table of contents with OCR: {}/{} pages".format(current, total)
+        )
+
+    def _toc_worker_finished(self):
+        self.auto_toc_button.setEnabled(True)
+        self._worker = None
+        self._worker_thread = None
 
     def pre_check(self, path, index_dict):
         try:

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -127,6 +127,7 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self._set_unwritable()
         self._worker = None
         self._worker_thread = None
+        self._worker_busy = False
         self._close_pending = False
 
     def _fix_small_fonts(self):
@@ -420,7 +421,7 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
             item.setExpanded(1)
 
     def fill_offset(self):
-        if self._worker_thread and self._worker_thread.isRunning():
+        if self._worker_busy:
             self.alert_msg("A background task is already running", level="warn")
             return
         if not self.pdf_path:
@@ -430,6 +431,7 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
             self.alert_msg("Please input directory text first", level="warn")
             return
 
+        self._worker_busy = True
         self.auto_offset_button.setEnabled(False)
         self.show_status("Inferring page offset, OCR may take a while...")
 
@@ -451,13 +453,14 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self._worker_thread.start()
 
     def fill_toc_text(self):
-        if self._worker_thread and self._worker_thread.isRunning():
+        if self._worker_busy:
             self.alert_msg("A background task is already running", level="warn")
             return
         if not self.pdf_path:
             self.alert_msg("Please select PDF first", level="warn")
             return
 
+        self._worker_busy = True
         self.auto_toc_button.setEnabled(False)
         self.show_status("Reading table of contents, OCR may take a while...")
 
@@ -504,6 +507,7 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self.auto_offset_button.setEnabled(True)
         self._worker = None
         self._worker_thread = None
+        self._worker_busy = False
         self._close_after_worker()
 
     def _toc_text_inferred(self, toc_text):
@@ -529,6 +533,7 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self.auto_toc_button.setEnabled(True)
         self._worker = None
         self._worker_thread = None
+        self._worker_busy = False
         self._close_after_worker()
 
     def _close_after_worker(self):

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -21,7 +21,7 @@ from src.gui.base import TreeWidget
 from src.gui.main_ui import Ui_PDFdir
 from src.updater import is_updated
 from src.pdf.bookmark import add_bookmark, check_bookmarks, get_bookmarks
-from src.pdf.page_offset import infer_page_offset
+from src.pdf.page_offset import OcrCancelledError, infer_page_offset
 from src.pdf.toc import extract_toc_text
 
 # import qdarkstyle
@@ -41,6 +41,7 @@ class ControlButtonMixin(object):
 class PageOffsetWorker(QtCore.QObject):
     finished = QtCore.pyqtSignal(object)
     failed = QtCore.pyqtSignal(str)
+    cancelled = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int, int)
 
     def __init__(self, pdf_path, dir_text):
@@ -56,7 +57,10 @@ class PageOffsetWorker(QtCore.QObject):
                 self.dir_text,
                 use_ocr=True,
                 progress_callback=self.progress.emit,
+                cancel_callback=QtCore.QThread.currentThread().isInterruptionRequested,
             )
+        except OcrCancelledError:
+            self.cancelled.emit()
         except Exception as e:
             self.failed.emit(str(e))
         else:
@@ -66,6 +70,7 @@ class PageOffsetWorker(QtCore.QObject):
 class TocTextWorker(QtCore.QObject):
     finished = QtCore.pyqtSignal(str)
     failed = QtCore.pyqtSignal(str)
+    cancelled = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int, int)
 
     def __init__(self, pdf_path):
@@ -79,7 +84,10 @@ class TocTextWorker(QtCore.QObject):
                 self.pdf_path,
                 use_ocr=True,
                 progress_callback=self.progress.emit,
+                cancel_callback=QtCore.QThread.currentThread().isInterruptionRequested,
             )
+        except OcrCancelledError:
+            self.cancelled.emit()
         except Exception as e:
             self.failed.emit(str(e))
         else:
@@ -119,6 +127,7 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self._set_unwritable()
         self._worker = None
         self._worker_thread = None
+        self._close_pending = False
 
     def _fix_small_fonts(self):
         """Override hardcoded small font sizes from main_ui.py for readability.
@@ -433,8 +442,10 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self._worker.progress.connect(self._offset_progress)
         self._worker.finished.connect(self._worker_thread.quit)
         self._worker.failed.connect(self._worker_thread.quit)
+        self._worker.cancelled.connect(self._worker_thread.quit)
         self._worker.finished.connect(self._worker.deleteLater)
         self._worker.failed.connect(self._worker.deleteLater)
+        self._worker.cancelled.connect(self._worker.deleteLater)
         self._worker_thread.finished.connect(self._worker_thread.deleteLater)
         self._worker_thread.finished.connect(self._offset_worker_finished)
         self._worker_thread.start()
@@ -459,23 +470,29 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self._worker.progress.connect(self._toc_progress)
         self._worker.finished.connect(self._worker_thread.quit)
         self._worker.failed.connect(self._worker_thread.quit)
+        self._worker.cancelled.connect(self._worker_thread.quit)
         self._worker.finished.connect(self._worker.deleteLater)
         self._worker.failed.connect(self._worker.deleteLater)
+        self._worker.cancelled.connect(self._worker.deleteLater)
         self._worker_thread.finished.connect(self._worker_thread.deleteLater)
         self._worker_thread.finished.connect(self._toc_worker_finished)
         self._worker_thread.start()
 
     def _offset_inferred(self, offset):
+        if self._close_pending:
+            return
         if offset is None:
             self.alert_msg("Could not infer page offset", level="warn")
             return
-        display_offset = offset - 1
+        display_offset = offset
         self.offset_edit.setText(str(display_offset))
         self.show_status(
             "Page offset inferred: {}".format(display_offset), 3000
         )
 
     def _offset_failed(self, message):
+        if self._close_pending:
+            return
         self.alert_msg("Infer page offset failed: {}".format(message), level="warn")
 
     def _offset_progress(self, current, total):
@@ -487,8 +504,11 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self.auto_offset_button.setEnabled(True)
         self._worker = None
         self._worker_thread = None
+        self._close_after_worker()
 
     def _toc_text_inferred(self, toc_text):
+        if self._close_pending:
+            return
         if not toc_text:
             self.alert_msg("Could not read table of contents", level="warn")
             return
@@ -496,6 +516,8 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self.show_status("Table of contents loaded", 3000)
 
     def _toc_text_failed(self, message):
+        if self._close_pending:
+            return
         self.alert_msg("Read table of contents failed: {}".format(message), level="warn")
 
     def _toc_progress(self, current, total):
@@ -507,6 +529,20 @@ class Main(QtWidgets.QMainWindow, Ui_PDFdir, ControlButtonMixin):
         self.auto_toc_button.setEnabled(True)
         self._worker = None
         self._worker_thread = None
+        self._close_after_worker()
+
+    def _close_after_worker(self):
+        if self._close_pending:
+            QtCore.QTimer.singleShot(0, self.close)
+
+    def closeEvent(self, event):
+        if self._worker_thread and self._worker_thread.isRunning():
+            self._close_pending = True
+            self._worker_thread.requestInterruption()
+            self.show_status("Cancelling background task...")
+            event.ignore()
+            return
+        super(Main, self).closeEvent(event)
 
     def pre_check(self, path, index_dict):
         try:

--- a/src/pdf/page_offset.py
+++ b/src/pdf/page_offset.py
@@ -3,15 +3,15 @@
 """Infer the page offset between printed page numbers and PDF pages."""
 
 import logging
+import math
 import os
 import re
 import sys
 from io import BytesIO
-from collections import Counter
 
 from pypdf import PdfReader
 
-from src.convert import COMPILED_PAGE_NUM_PATTERNS, split_page_num, text_to_list
+from src.convert import COMPILED_PAGE_NUM_PATTERNS, text_to_list
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +131,11 @@ def _infer_page_offset_from_candidates(candidates, page_texts, log_insufficient=
         _, match = item
         return (len(match["candidates"]), len(match["pages"]))
 
-    best_offset, best_match = max(offset_matches.items(), key=score)
+    ranked_offsets = sorted(offset_matches.items(), key=score, reverse=True)
+    best_offset, best_match = ranked_offsets[0]
+    if len(ranked_offsets) > 1 and score(ranked_offsets[1]) == score(ranked_offsets[0]):
+        logger.warning("Infer page offset is ambiguous")
+        return None
     if len(best_match["candidates"]) >= 2 and len(best_match["pages"]) >= 2:
         return best_offset
 
@@ -184,7 +188,7 @@ def _load_ocr_dependencies():
             "OCR fallback requires PyMuPDF, Pillow, pytesseract, and Tesseract OCR"
         ) from e
     tesseract_path = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
-    if os.path.exists(tesseract_path):
+    if os.name == "nt" and os.path.exists(tesseract_path):
         pytesseract.pytesseract.tesseract_cmd = tesseract_path
     return fitz, pytesseract, Image
 
@@ -192,56 +196,20 @@ def _load_ocr_dependencies():
 def _tesseract_config():
     tessdata_dir = os.path.join(sys.prefix, "tessdata")
     if os.path.isdir(tessdata_dir):
-        return "--tessdata-dir {}".format(tessdata_dir)
+        return '--tessdata-dir "{}"'.format(tessdata_dir)
     return ""
 
 
-def extract_pdf_texts_by_ocr(
-    pdf_path,
-    max_pages=120,
-    dpi=160,
-    languages="chi_sim+eng",
-    progress_callback=None,
-    cancel_callback=None,
-    timeout=30,
-):
-    """Extract page texts by rendering pages and running OCR.
-
-    This fallback is intentionally bounded because OCR on a full book can be
-    very slow. It is enough for page-offset inference, which usually only needs
-    the first few directory entries.
-    """
-    fitz, pytesseract, Image = _load_ocr_dependencies()
-    page_texts = []
+def _render_matrix(fitz, page, dpi, max_pixels=16_000_000):
     scale = dpi / 72.0
-    matrix = fitz.Matrix(scale, scale)
-    tesseract_config = _tesseract_config()
-
-    try:
-        document = fitz.open(pdf_path)
-    except Exception as e:
-        raise OcrUnavailableError("Open PDF for OCR failed: {}".format(e)) from e
-
-    try:
-        page_count = min(len(document), max_pages)
-        for page_index in range(page_count):
-            _check_cancelled(cancel_callback)
-            page = document.load_page(page_index)
-            pixmap = page.get_pixmap(matrix=matrix, alpha=False)
-            image = Image.open(BytesIO(pixmap.tobytes("png")))
-            try:
-                text = pytesseract.image_to_string(
-                    image, lang=languages, config=tesseract_config, timeout=timeout
-                )
-            except Exception as e:
-                raise OcrUnavailableError("OCR page text failed: {}".format(e)) from e
-            page_texts.append(text or "")
-            if progress_callback:
-                progress_callback(page_index + 1, page_count)
-    finally:
-        document.close()
-
-    return page_texts
+    rect = getattr(page, "rect", None)
+    if rect is not None:
+        pixel_count = (
+            max(float(rect.width), 1) * max(float(rect.height), 1) * scale**2
+        )
+        if pixel_count > max_pixels:
+            scale *= math.sqrt(max_pixels / pixel_count)
+    return fitz.Matrix(scale, scale)
 
 
 def infer_page_offset_by_ocr(
@@ -262,8 +230,6 @@ def infer_page_offset_by_ocr(
 
     fitz, pytesseract, Image = _load_ocr_dependencies()
     page_texts = []
-    scale = dpi / 72.0
-    matrix = fitz.Matrix(scale, scale)
     tesseract_config = _tesseract_config()
 
     try:
@@ -273,9 +239,12 @@ def infer_page_offset_by_ocr(
 
     try:
         page_count = min(len(document), max_pages)
+        first_ocr_error = None
+        successful_pages = 0
         for page_index in range(page_count):
             _check_cancelled(cancel_callback)
             page = document.load_page(page_index)
+            matrix = _render_matrix(fitz, page, dpi)
             pixmap = page.get_pixmap(matrix=matrix, alpha=False)
             image = Image.open(BytesIO(pixmap.tobytes("png")))
             try:
@@ -283,7 +252,12 @@ def infer_page_offset_by_ocr(
                     image, lang=languages, config=tesseract_config, timeout=timeout
                 )
             except Exception as e:
-                raise OcrUnavailableError("OCR page text failed: {}".format(e)) from e
+                logger.warning("OCR page %d failed: %s", page_index + 1, e)
+                if first_ocr_error is None:
+                    first_ocr_error = e
+                text = ""
+            else:
+                successful_pages += 1
             page_texts.append(text or "")
             if progress_callback:
                 progress_callback(page_index + 1, page_count)
@@ -296,6 +270,10 @@ def infer_page_offset_by_ocr(
     finally:
         document.close()
 
+    if not successful_pages and first_ocr_error is not None:
+        raise OcrUnavailableError(
+            "OCR page text failed: {}".format(first_ocr_error)
+        ) from first_ocr_error
     return _infer_page_offset_from_candidates(candidates, page_texts)
 
 

--- a/src/pdf/page_offset.py
+++ b/src/pdf/page_offset.py
@@ -20,6 +20,15 @@ class OcrUnavailableError(RuntimeError):
     """Raised when OCR fallback cannot run in the current environment."""
 
 
+class OcrCancelledError(RuntimeError):
+    """Raised when an OCR operation is cancelled."""
+
+
+def _check_cancelled(cancel_callback):
+    if cancel_callback and cancel_callback():
+        raise OcrCancelledError("OCR operation cancelled")
+
+
 def normalize_page_text(text):
     """Normalize text so titles can match despite whitespace differences."""
     if not text:
@@ -109,8 +118,6 @@ def _infer_page_offset_from_candidates(candidates, page_texts, log_insufficient=
 
         for candidate_index, printed_num in page_matches:
             offset = page_index + 1 - printed_num
-            if offset < 0:
-                continue
             match = offset_matches.setdefault(
                 offset, {"pages": set(), "candidates": set()}
             )
@@ -150,12 +157,15 @@ def infer_page_offset_from_texts(dir_text, page_texts, max_entries=20):
     return _infer_page_offset_from_candidates(candidates, page_texts)
 
 
-def extract_pdf_texts(pdf_path):
+def extract_pdf_texts(pdf_path, max_pages=None, cancel_callback=None):
     """Extract page texts from a PDF text layer."""
     page_texts = []
     with open(pdf_path, "rb") as handle:
         reader = PdfReader(handle, strict=False)
-        for page in reader.pages:
+        for page_index, page in enumerate(reader.pages):
+            if max_pages is not None and page_index >= max_pages:
+                break
+            _check_cancelled(cancel_callback)
             try:
                 page_texts.append(page.extract_text() or "")
             except Exception as e:
@@ -192,6 +202,8 @@ def extract_pdf_texts_by_ocr(
     dpi=160,
     languages="chi_sim+eng",
     progress_callback=None,
+    cancel_callback=None,
+    timeout=30,
 ):
     """Extract page texts by rendering pages and running OCR.
 
@@ -213,12 +225,13 @@ def extract_pdf_texts_by_ocr(
     try:
         page_count = min(len(document), max_pages)
         for page_index in range(page_count):
+            _check_cancelled(cancel_callback)
             page = document.load_page(page_index)
             pixmap = page.get_pixmap(matrix=matrix, alpha=False)
             image = Image.open(BytesIO(pixmap.tobytes("png")))
             try:
                 text = pytesseract.image_to_string(
-                    image, lang=languages, config=tesseract_config
+                    image, lang=languages, config=tesseract_config, timeout=timeout
                 )
             except Exception as e:
                 raise OcrUnavailableError("OCR page text failed: {}".format(e)) from e
@@ -239,6 +252,8 @@ def infer_page_offset_by_ocr(
     dpi=160,
     languages="chi_sim+eng",
     progress_callback=None,
+    cancel_callback=None,
+    timeout=30,
 ):
     """Infer page offset by OCR, stopping as soon as enough evidence exists."""
     candidates = list(iter_toc_candidates(dir_text, max_entries=max_entries))
@@ -259,12 +274,13 @@ def infer_page_offset_by_ocr(
     try:
         page_count = min(len(document), max_pages)
         for page_index in range(page_count):
+            _check_cancelled(cancel_callback)
             page = document.load_page(page_index)
             pixmap = page.get_pixmap(matrix=matrix, alpha=False)
             image = Image.open(BytesIO(pixmap.tobytes("png")))
             try:
                 text = pytesseract.image_to_string(
-                    image, lang=languages, config=tesseract_config
+                    image, lang=languages, config=tesseract_config, timeout=timeout
                 )
             except Exception as e:
                 raise OcrUnavailableError("OCR page text failed: {}".format(e)) from e
@@ -291,9 +307,11 @@ def infer_page_offset(
     ocr_max_pages=120,
     ocr_languages="chi_sim+eng",
     progress_callback=None,
+    cancel_callback=None,
+    ocr_timeout=30,
 ):
     """Infer page offset from a PDF and directory text."""
-    page_texts = extract_pdf_texts(pdf_path)
+    page_texts = extract_pdf_texts(pdf_path, cancel_callback=cancel_callback)
     offset = infer_page_offset_from_texts(
         dir_text, page_texts, max_entries=max_entries
     )
@@ -307,4 +325,6 @@ def infer_page_offset(
         max_pages=ocr_max_pages,
         languages=ocr_languages,
         progress_callback=progress_callback,
+        cancel_callback=cancel_callback,
+        timeout=ocr_timeout,
     )

--- a/src/pdf/page_offset.py
+++ b/src/pdf/page_offset.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+
+"""Infer the page offset between printed page numbers and PDF pages."""
+
+import logging
+import os
+import re
+import sys
+from io import BytesIO
+from collections import Counter
+
+from pypdf import PdfReader
+
+from src.convert import COMPILED_PAGE_NUM_PATTERNS, split_page_num, text_to_list
+
+logger = logging.getLogger(__name__)
+
+
+class OcrUnavailableError(RuntimeError):
+    """Raised when OCR fallback cannot run in the current environment."""
+
+
+def normalize_page_text(text):
+    """Normalize text so titles can match despite whitespace differences."""
+    if not text:
+        return ""
+    return re.sub(r"\s+", "", text).lower()
+
+
+def split_explicit_page_num(text):
+    """Return (title, page_num) only when a line explicitly ends with a page number."""
+    for pat in COMPILED_PAGE_NUM_PATTERNS[:-1]:
+        res = pat.search(text)
+        if not res:
+            continue
+        title, num = res.groups()
+        title = title.rstrip(" .-")
+        if title and num:
+            return title, int(num)
+    return None, None
+
+
+def iter_toc_candidates(dir_text, max_entries=20, min_title_len=2):
+    """Yield (title, printed_page_num) candidates parsed from directory text."""
+    for line in text_to_list(dir_text):
+        title, num = split_explicit_page_num(line.rstrip())
+        if title is None:
+            continue
+        title = title.strip()
+        normalized_title = normalize_page_text(title)
+        if len(normalized_title) < min_title_len:
+            continue
+        yield title, num
+        max_entries -= 1
+        if max_entries <= 0:
+            break
+
+
+def _title_grams(title, gram_size):
+    return {
+        title[i : i + gram_size]
+        for i in range(len(title) - gram_size + 1)
+    }
+
+
+def _has_non_ascii(text):
+    return any(ord(char) > 127 for char in text)
+
+
+def page_contains_title(title, page_text, fuzzy=True):
+    """Return True when extracted page text appears to contain the title."""
+    normalized_title = normalize_page_text(title)
+    normalized_page = normalize_page_text(page_text)
+    if not normalized_title or not normalized_page:
+        return False
+    if normalized_title in normalized_page:
+        return True
+    if not fuzzy or len(normalized_title) < 4 or not _has_non_ascii(normalized_title):
+        return False
+
+    gram_size = 3 if len(normalized_title) >= 8 else 2
+    grams = _title_grams(normalized_title, gram_size)
+    if not grams:
+        return False
+    matched = sum(1 for gram in grams if gram in normalized_page)
+    return matched / float(len(grams)) >= 0.6
+
+
+def _looks_like_contents_page(page_text, matched_count):
+    normalized_page = normalize_page_text(page_text)
+    if matched_count >= 3:
+        return True
+    return matched_count >= 2 and (
+        "contents" in normalized_page or "目录" in normalized_page
+    )
+
+
+def _infer_page_offset_from_candidates(candidates, page_texts, log_insufficient=True):
+    offset_matches = {}
+
+    for page_index, page_text in enumerate(page_texts):
+        page_matches = []
+        for candidate_index, (title, printed_num) in enumerate(candidates):
+            if page_contains_title(title, page_text):
+                page_matches.append((candidate_index, printed_num))
+
+        if _looks_like_contents_page(page_text, len(page_matches)):
+            continue
+
+        for candidate_index, printed_num in page_matches:
+            offset = page_index + 1 - printed_num
+            if offset < 0:
+                continue
+            match = offset_matches.setdefault(
+                offset, {"pages": set(), "candidates": set()}
+            )
+            match["pages"].add(page_index)
+            match["candidates"].add(candidate_index)
+
+    if not offset_matches:
+        return None
+
+    def score(item):
+        _, match = item
+        return (len(match["candidates"]), len(match["pages"]))
+
+    best_offset, best_match = max(offset_matches.items(), key=score)
+    if len(best_match["candidates"]) >= 2 and len(best_match["pages"]) >= 2:
+        return best_offset
+
+    if log_insufficient:
+        logger.warning("Infer page offset does not have enough matching titles")
+
+    return None
+
+
+def infer_page_offset_from_texts(dir_text, page_texts, max_entries=20):
+    """Infer offset using repeated title matches across extracted PDF pages.
+
+    Each matching page creates a candidate offset:
+        offset = real_pdf_page_number - printed_page_number
+
+    The correct offset should be shared by multiple table-of-contents entries.
+    False matches on the contents page usually produce inconsistent offsets.
+    """
+    candidates = list(iter_toc_candidates(dir_text, max_entries=max_entries))
+    if len(candidates) < 2:
+        return None
+
+    return _infer_page_offset_from_candidates(candidates, page_texts)
+
+
+def extract_pdf_texts(pdf_path):
+    """Extract page texts from a PDF text layer."""
+    page_texts = []
+    with open(pdf_path, "rb") as handle:
+        reader = PdfReader(handle, strict=False)
+        for page in reader.pages:
+            try:
+                page_texts.append(page.extract_text() or "")
+            except Exception as e:
+                logger.warning("Extract page text failed: %s", e)
+                page_texts.append("")
+    return page_texts
+
+
+def _load_ocr_dependencies():
+    try:
+        import fitz
+        import pytesseract
+        from PIL import Image
+    except ImportError as e:
+        raise OcrUnavailableError(
+            "OCR fallback requires PyMuPDF, Pillow, pytesseract, and Tesseract OCR"
+        ) from e
+    tesseract_path = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
+    if os.path.exists(tesseract_path):
+        pytesseract.pytesseract.tesseract_cmd = tesseract_path
+    return fitz, pytesseract, Image
+
+
+def _tesseract_config():
+    tessdata_dir = os.path.join(sys.prefix, "tessdata")
+    if os.path.isdir(tessdata_dir):
+        return "--tessdata-dir {}".format(tessdata_dir)
+    return ""
+
+
+def extract_pdf_texts_by_ocr(
+    pdf_path,
+    max_pages=120,
+    dpi=160,
+    languages="chi_sim+eng",
+    progress_callback=None,
+):
+    """Extract page texts by rendering pages and running OCR.
+
+    This fallback is intentionally bounded because OCR on a full book can be
+    very slow. It is enough for page-offset inference, which usually only needs
+    the first few directory entries.
+    """
+    fitz, pytesseract, Image = _load_ocr_dependencies()
+    page_texts = []
+    scale = dpi / 72.0
+    matrix = fitz.Matrix(scale, scale)
+    tesseract_config = _tesseract_config()
+
+    try:
+        document = fitz.open(pdf_path)
+    except Exception as e:
+        raise OcrUnavailableError("Open PDF for OCR failed: {}".format(e)) from e
+
+    try:
+        page_count = min(len(document), max_pages)
+        for page_index in range(page_count):
+            page = document.load_page(page_index)
+            pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+            image = Image.open(BytesIO(pixmap.tobytes("png")))
+            try:
+                text = pytesseract.image_to_string(
+                    image, lang=languages, config=tesseract_config
+                )
+            except Exception as e:
+                raise OcrUnavailableError("OCR page text failed: {}".format(e)) from e
+            page_texts.append(text or "")
+            if progress_callback:
+                progress_callback(page_index + 1, page_count)
+    finally:
+        document.close()
+
+    return page_texts
+
+
+def infer_page_offset_by_ocr(
+    pdf_path,
+    dir_text,
+    max_entries=20,
+    max_pages=120,
+    dpi=160,
+    languages="chi_sim+eng",
+    progress_callback=None,
+):
+    """Infer page offset by OCR, stopping as soon as enough evidence exists."""
+    candidates = list(iter_toc_candidates(dir_text, max_entries=max_entries))
+    if len(candidates) < 2:
+        return None
+
+    fitz, pytesseract, Image = _load_ocr_dependencies()
+    page_texts = []
+    scale = dpi / 72.0
+    matrix = fitz.Matrix(scale, scale)
+    tesseract_config = _tesseract_config()
+
+    try:
+        document = fitz.open(pdf_path)
+    except Exception as e:
+        raise OcrUnavailableError("Open PDF for OCR failed: {}".format(e)) from e
+
+    try:
+        page_count = min(len(document), max_pages)
+        for page_index in range(page_count):
+            page = document.load_page(page_index)
+            pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+            image = Image.open(BytesIO(pixmap.tobytes("png")))
+            try:
+                text = pytesseract.image_to_string(
+                    image, lang=languages, config=tesseract_config
+                )
+            except Exception as e:
+                raise OcrUnavailableError("OCR page text failed: {}".format(e)) from e
+            page_texts.append(text or "")
+            if progress_callback:
+                progress_callback(page_index + 1, page_count)
+
+            offset = _infer_page_offset_from_candidates(
+                candidates, page_texts, log_insufficient=False
+            )
+            if offset is not None:
+                return offset
+    finally:
+        document.close()
+
+    return _infer_page_offset_from_candidates(candidates, page_texts)
+
+
+def infer_page_offset(
+    pdf_path,
+    dir_text,
+    max_entries=20,
+    use_ocr=False,
+    ocr_max_pages=120,
+    ocr_languages="chi_sim+eng",
+    progress_callback=None,
+):
+    """Infer page offset from a PDF and directory text."""
+    page_texts = extract_pdf_texts(pdf_path)
+    offset = infer_page_offset_from_texts(
+        dir_text, page_texts, max_entries=max_entries
+    )
+    if offset is not None or not use_ocr:
+        return offset
+
+    return infer_page_offset_by_ocr(
+        pdf_path,
+        dir_text,
+        max_entries=max_entries,
+        max_pages=ocr_max_pages,
+        languages=ocr_languages,
+        progress_callback=progress_callback,
+    )

--- a/src/pdf/toc.py
+++ b/src/pdf/toc.py
@@ -8,7 +8,9 @@ import sys
 from io import BytesIO
 
 from src.pdf.page_offset import (
+    OcrCancelledError,
     OcrUnavailableError,
+    _check_cancelled,
     _load_ocr_dependencies,
     _tesseract_config,
     extract_pdf_texts,
@@ -519,6 +521,9 @@ def _collect_paddleocr_texts(result):
                 if isinstance(value, list):
                     texts.extend(str(text) for text in value if text)
                     return
+            if "res" in item:
+                collect(item["res"])
+                return
             text = item.get("text")
             if isinstance(text, str) and text:
                 texts.append(text)
@@ -580,6 +585,7 @@ def extract_toc_text_by_paddleocr(
     dpi=130,
     languages="ch",
     progress_callback=None,
+    cancel_callback=None,
 ):
     np, ocr = _load_paddleocr_dependencies(languages)
     page_toc_entries = []
@@ -588,6 +594,7 @@ def extract_toc_text_by_paddleocr(
 
     try:
         for page_index, page_count, image in _render_pdf_pages(pdf_path, max_pages, dpi):
+            _check_cancelled(cancel_callback)
             text = _paddleocr_image_to_text(ocr, np, image)
             page_entries = _extract_toc_entries_from_text(text)
             page_toc_entries.append(page_entries)
@@ -602,7 +609,7 @@ def extract_toc_text_by_paddleocr(
                 if weak_pages_after_toc >= 2:
                     break
     except Exception as e:
-        if isinstance(e, OcrUnavailableError):
+        if isinstance(e, (OcrUnavailableError, OcrCancelledError)):
             raise
         raise OcrUnavailableError("PaddleOCR page text failed: {}".format(e)) from e
 
@@ -615,6 +622,8 @@ def extract_toc_text_by_tesseract(
     dpi=240,
     languages="chi_sim+eng",
     progress_callback=None,
+    cancel_callback=None,
+    timeout=30,
 ):
     fitz, pytesseract, Image = _load_ocr_dependencies()
     scale = dpi / 72.0
@@ -626,12 +635,13 @@ def extract_toc_text_by_tesseract(
     try:
         page_count = min(len(document), max_pages)
         for page_index in range(page_count):
+            _check_cancelled(cancel_callback)
             page = document.load_page(page_index)
             pixmap = page.get_pixmap(matrix=matrix, alpha=False)
             image = Image.open(BytesIO(pixmap.tobytes("png")))
             page_texts.append(
                 pytesseract.image_to_string(
-                    image, lang=languages, config=config
+                    image, lang=languages, config=config, timeout=timeout
                 )
             )
             if progress_callback:
@@ -650,6 +660,8 @@ def extract_toc_text_by_ocr(
     progress_callback=None,
     backend="paddle",
     fallback_to_tesseract=True,
+    cancel_callback=None,
+    timeout=30,
 ):
     if backend == "tesseract":
         return extract_toc_text_by_tesseract(
@@ -658,6 +670,8 @@ def extract_toc_text_by_ocr(
             dpi=240 if dpi == 220 else dpi,
             languages="chi_sim+eng",
             progress_callback=progress_callback,
+            cancel_callback=cancel_callback,
+            timeout=timeout,
         )
     if backend != "paddle":
         raise ValueError("Unknown OCR backend: {}".format(backend))
@@ -669,6 +683,7 @@ def extract_toc_text_by_ocr(
             dpi=dpi,
             languages=languages,
             progress_callback=progress_callback,
+            cancel_callback=cancel_callback,
         )
         if toc_text or not fallback_to_tesseract:
             return toc_text
@@ -680,6 +695,8 @@ def extract_toc_text_by_ocr(
         pdf_path,
         max_pages=max_pages,
         progress_callback=progress_callback,
+        cancel_callback=cancel_callback,
+        timeout=timeout,
     )
 
 
@@ -689,8 +706,12 @@ def extract_toc_text(
     use_ocr=True,
     ocr_backend="paddle",
     progress_callback=None,
+    cancel_callback=None,
+    ocr_timeout=30,
 ):
-    page_texts = extract_pdf_texts(pdf_path)[:max_pages]
+    page_texts = extract_pdf_texts(
+        pdf_path, max_pages=max_pages, cancel_callback=cancel_callback
+    )
     toc_text = extract_toc_text_from_page_texts(page_texts)
     if toc_text or not use_ocr:
         return toc_text
@@ -700,4 +721,6 @@ def extract_toc_text(
         max_pages=max_pages,
         backend=ocr_backend,
         progress_callback=progress_callback,
+        cancel_callback=cancel_callback,
+        timeout=ocr_timeout,
     )

--- a/src/pdf/toc.py
+++ b/src/pdf/toc.py
@@ -596,8 +596,6 @@ def _paddleocr_image_to_text(ocr, np, image):
         result = ocr.ocr(image_array, cls=True)
     except TypeError:
         result = ocr.ocr(image_array)
-    except AttributeError:
-        result = ocr.predict(image_array)
     return "\n".join(_collect_paddleocr_texts(result))
 
 

--- a/src/pdf/toc.py
+++ b/src/pdf/toc.py
@@ -2,9 +2,9 @@
 
 """Extract table-of-contents text from PDF pages."""
 
+import logging
 import os
 import re
-import sys
 from io import BytesIO
 
 from src.pdf.page_offset import (
@@ -12,10 +12,13 @@ from src.pdf.page_offset import (
     OcrUnavailableError,
     _check_cancelled,
     _load_ocr_dependencies,
+    _render_matrix,
     _tesseract_config,
     extract_pdf_texts,
     normalize_page_text,
 )
+
+logger = logging.getLogger(__name__)
 
 
 _TOC_LINE_PATTERN = re.compile(r".{2,}\d+\s*$")
@@ -136,10 +139,6 @@ def _merge_wrapped_toc_lines(text, max_fragments=4):
 
     flush_title_only_pending()
     return merged_lines
-
-
-def _normalize_latin_token(token):
-    return re.sub(r"[^A-Za-z0-9-]+", "", token).lower()
 
 
 def _has_cjk(text):
@@ -286,10 +285,6 @@ def _looks_like_toc_page(text):
     return "目录" in normalized or "contents" in normalized or toc_line_count >= 3
 
 
-def _extract_toc_lines_from_text(text):
-    return [entry[0] for entry in _extract_toc_entries_from_text(text)]
-
-
 def _extract_toc_entries_from_text(text):
     page_entries = []
     if not text:
@@ -393,6 +388,14 @@ def extract_toc_text_from_page_texts(page_texts):
         page_toc_entries.append(_extract_toc_entries_from_text(text))
 
     selected_lines = _select_toc_page_block(page_toc_entries)
+    if not selected_lines:
+        for text, page_entries in zip(page_texts, page_toc_entries):
+            if (
+                _looks_like_toc_page(text)
+                and _toc_entry_count(page_entries, require_page=True) >= 2
+            ):
+                selected_lines = [line for line, _ in page_entries]
+                break
     return "\n".join(selected_lines)
 
 
@@ -464,8 +467,12 @@ def _load_render_dependencies():
 
 
 def _load_paddleocr_dependencies(languages="ch"):
-    cache_root = os.path.join(sys.prefix, "paddle_cache")
-    os.environ.setdefault("XDG_CACHE_HOME", cache_root)
+    cache_root = os.path.join(
+        os.environ.get(
+            "XDG_CACHE_HOME", os.path.expanduser(os.path.join("~", ".cache"))
+        ),
+        "pdfdir",
+    )
     os.environ.setdefault("PADDLE_HOME", os.path.join(cache_root, "paddle"))
     os.environ.setdefault(
         "PADDLE_PDX_CACHE_HOME", os.path.join(cache_root, "paddlex")
@@ -483,20 +490,25 @@ def _load_paddleocr_dependencies(languages="ch"):
 
     lang = _paddleocr_lang(languages)
     try:
-        ocr = PaddleOCR(
-            lang=lang,
-            text_detection_model_name="PP-OCRv5_mobile_det",
-            text_recognition_model_name="PP-OCRv5_mobile_rec",
-            use_doc_orientation_classify=False,
-            use_doc_unwarping=False,
-            use_textline_orientation=False,
-            text_det_limit_side_len=1280,
-        )
-    except (TypeError, ValueError):
         try:
-            ocr = PaddleOCR(lang=lang, use_textline_orientation=False)
+            ocr = PaddleOCR(
+                lang=lang,
+                text_detection_model_name="PP-OCRv5_mobile_det",
+                text_recognition_model_name="PP-OCRv5_mobile_rec",
+                use_doc_orientation_classify=False,
+                use_doc_unwarping=False,
+                use_textline_orientation=False,
+                text_det_limit_side_len=1280,
+            )
         except (TypeError, ValueError):
-            ocr = PaddleOCR(lang=lang)
+            try:
+                ocr = PaddleOCR(lang=lang, use_textline_orientation=False)
+            except (TypeError, ValueError):
+                ocr = PaddleOCR(lang=lang)
+    except Exception as e:
+        raise OcrUnavailableError(
+            "Initialize PaddleOCR failed: {}".format(e)
+        ) from e
     return np, ocr
 
 
@@ -549,14 +561,13 @@ def _collect_paddleocr_texts(result):
 
 def _render_pdf_pages(pdf_path, max_pages, dpi):
     fitz, Image = _load_render_dependencies()
-    scale = dpi / 72.0
-    matrix = fitz.Matrix(scale, scale)
 
     document = fitz.open(pdf_path)
     try:
         page_count = min(len(document), max_pages)
         for page_index in range(page_count):
             page = document.load_page(page_index)
+            matrix = _render_matrix(fitz, page, dpi)
             pixmap = page.get_pixmap(matrix=matrix, alpha=False)
             image = Image.open(BytesIO(pixmap.tobytes("png"))).convert("RGB")
             yield page_index, page_count, image
@@ -588,7 +599,7 @@ def extract_toc_text_by_paddleocr(
     cancel_callback=None,
 ):
     np, ocr = _load_paddleocr_dependencies(languages)
-    page_toc_entries = []
+    page_texts = []
     seen_toc_page = False
     weak_pages_after_toc = 0
 
@@ -596,8 +607,8 @@ def extract_toc_text_by_paddleocr(
         for page_index, page_count, image in _render_pdf_pages(pdf_path, max_pages, dpi):
             _check_cancelled(cancel_callback)
             text = _paddleocr_image_to_text(ocr, np, image)
+            page_texts.append(text)
             page_entries = _extract_toc_entries_from_text(text)
-            page_toc_entries.append(page_entries)
             if progress_callback:
                 progress_callback(page_index + 1, page_count)
 
@@ -613,7 +624,7 @@ def extract_toc_text_by_paddleocr(
             raise
         raise OcrUnavailableError("PaddleOCR page text failed: {}".format(e)) from e
 
-    return "\n".join(_select_toc_page_block(page_toc_entries))
+    return extract_toc_text_from_page_texts(page_texts)
 
 
 def extract_toc_text_by_tesseract(
@@ -626,29 +637,41 @@ def extract_toc_text_by_tesseract(
     timeout=30,
 ):
     fitz, pytesseract, Image = _load_ocr_dependencies()
-    scale = dpi / 72.0
-    matrix = fitz.Matrix(scale, scale)
     config = "{} --psm 4 -c preserve_interword_spaces=1".format(_tesseract_config())
     page_texts = []
 
     document = fitz.open(pdf_path)
     try:
         page_count = min(len(document), max_pages)
+        first_ocr_error = None
+        successful_pages = 0
         for page_index in range(page_count):
             _check_cancelled(cancel_callback)
             page = document.load_page(page_index)
+            matrix = _render_matrix(fitz, page, dpi)
             pixmap = page.get_pixmap(matrix=matrix, alpha=False)
             image = Image.open(BytesIO(pixmap.tobytes("png")))
-            page_texts.append(
-                pytesseract.image_to_string(
+            try:
+                text = pytesseract.image_to_string(
                     image, lang=languages, config=config, timeout=timeout
                 )
-            )
+            except Exception as e:
+                logger.warning("OCR page %d failed: %s", page_index + 1, e)
+                if first_ocr_error is None:
+                    first_ocr_error = e
+                text = ""
+            else:
+                successful_pages += 1
+            page_texts.append(text or "")
             if progress_callback:
                 progress_callback(page_index + 1, page_count)
     finally:
         document.close()
 
+    if not successful_pages and first_ocr_error is not None:
+        raise OcrUnavailableError(
+            "OCR page text failed: {}".format(first_ocr_error)
+        ) from first_ocr_error
     return extract_toc_text_from_page_texts(page_texts)
 
 

--- a/src/pdf/toc.py
+++ b/src/pdf/toc.py
@@ -1,0 +1,703 @@
+# -*- coding: utf-8 -*-
+
+"""Extract table-of-contents text from PDF pages."""
+
+import os
+import re
+import sys
+from io import BytesIO
+
+from src.pdf.page_offset import (
+    OcrUnavailableError,
+    _load_ocr_dependencies,
+    _tesseract_config,
+    extract_pdf_texts,
+    normalize_page_text,
+)
+
+
+_TOC_LINE_PATTERN = re.compile(r".{2,}\d+\s*$")
+_DOT_LEADER_PATTERN = re.compile(r"[\s.\-·•…]{2,}(\d+)\s*$")
+_TITLE_PAGE_PATTERN = re.compile(r"(?P<title>.+?)[\s.\-·•…]*(?P<num>\d+)\s*$")
+_PAGE_NUMBER_FRAGMENT_PATTERN = re.compile(r"^[\s.\-·•…]*(\d+)\s*$")
+_SECTION_NUMBER_ONLY_PATTERN = re.compile(r"^[#\d\s.:：]+$")
+_NOISY_TITLE_PATTERN = re.compile(
+    r"(isbn|版权|合同|登记号|邮编|出版社|印刷|发行|copyright|http|www|mod\b|=)"
+    r"|([a-z]\))",
+    re.IGNORECASE,
+)
+
+
+_LONG_LATIN_NOISE_PATTERN = re.compile(r"[A-Za-z]{18,}")
+
+
+def _clean_toc_line(line):
+    line = re.sub(r"\s+", " ", line.strip())
+    line = _DOT_LEADER_PATTERN.sub(r" \1", line)
+    if not re.match(r"^[§$]?\d+([.:：]\d+)+\s*$", line):
+        line = re.sub(r"([^\d\s])(\d+)\s*$", r"\1 \2", line)
+    return line.strip()
+
+
+def _looks_like_toc_fragment(line):
+    if not line:
+        return False
+    return bool(
+        re.search(r"[\u4e00-\u9fffA-Za-z]", line)
+        or re.match(r"^[§$]?\d+([.:：]\d+)*", line)
+    )
+
+
+def _starts_new_toc_entry(line):
+    return bool(
+        re.match(r"^(第\s*\d+\s*章|[§$]?\d+([.:：]\d+)*|习题|附录)", line)
+    )
+
+
+def _is_title_only_toc_line(line):
+    cleaned = _clean_title_noise(_clean_toc_line(line))
+    if not cleaned:
+        return False
+    if cleaned in ("目录", "目 录"):
+        return False
+    if cleaned.lower() == "contents":
+        return False
+    if _TOC_LINE_PATTERN.match(cleaned):
+        return False
+    if _SECTION_NUMBER_ONLY_PATTERN.match(cleaned):
+        return False
+    if _NOISY_TITLE_PATTERN.search(cleaned):
+        return False
+    if not re.match(r"^(第\s*\d+\s*章\s*\S+|[§$]?\d+([.:：]\d+)+\s*\S+)", cleaned):
+        return False
+
+    title_chars = re.findall(r"[\u4e00-\u9fffA-Za-z]", cleaned)
+    return len(title_chars) >= 2
+
+
+def _can_keep_toc_title_without_page(title):
+    cleaned = _clean_title_noise(_clean_toc_line(title))
+    if not cleaned:
+        return False
+    if cleaned in ("目录", "目 录"):
+        return False
+    if cleaned.lower() == "contents":
+        return False
+    if _SECTION_NUMBER_ONLY_PATTERN.match(cleaned):
+        return False
+    if _NOISY_TITLE_PATTERN.search(cleaned):
+        return False
+    if not re.match(r"^(第\s*\d+\s*章|[§$]?\d+([.:：]\d+)+|习题|附录)", cleaned):
+        return False
+
+    title_chars = re.findall(r"[\u4e00-\u9fffA-Za-z]", cleaned)
+    return len(title_chars) >= 2
+
+
+def _merge_wrapped_toc_lines(text, max_fragments=4):
+    merged_lines = []
+    pending = []
+
+    def pending_text():
+        return " ".join(pending).strip()
+
+    def flush_title_only_pending():
+        text = pending_text()
+        if _is_title_only_toc_line(text):
+            merged_lines.append(text)
+
+    for raw_line in text.splitlines():
+        line = _clean_toc_line(raw_line)
+        if not line:
+            continue
+
+        page_match = _PAGE_NUMBER_FRAGMENT_PATTERN.match(line)
+        if page_match and pending:
+            merged_lines.append("{} {}".format(pending_text(), page_match.group(1)))
+            pending = []
+            continue
+
+        if _is_toc_line(line):
+            merged_lines.append(line)
+            pending = []
+            continue
+
+        if not _looks_like_toc_fragment(line):
+            continue
+
+        if pending and _starts_new_toc_entry(line):
+            flush_title_only_pending()
+            pending = []
+        pending.append(line)
+        if len(pending) > max_fragments:
+            pending = pending[-max_fragments:]
+
+    flush_title_only_pending()
+    return merged_lines
+
+
+def _normalize_latin_token(token):
+    return re.sub(r"[^A-Za-z0-9-]+", "", token).lower()
+
+
+def _has_cjk(text):
+    return bool(re.search(r"[\u4e00-\u9fff]", text))
+
+
+def _is_heading_number(token):
+    return bool(re.match(r"^\d+([.:]\d+)*[.:]?$", token))
+
+
+def _looks_like_regular_latin_word(token):
+    normalized = re.sub(r"[^A-Za-z-]+", "", token)
+    if not 4 <= len(normalized) <= 24:
+        return False
+    if _LONG_LATIN_NOISE_PATTERN.search(normalized):
+        return False
+    if not re.match(r"^[A-Za-z]+(?:-[A-Za-z]+)*$", normalized):
+        return False
+
+    letters = normalized.replace("-", "")
+    uppercase_count = sum(1 for char in letters if char.isupper())
+    lowercase_count = sum(1 for char in letters if char.islower())
+    if uppercase_count == 0:
+        return False
+    if lowercase_count < 2:
+        return False
+    return uppercase_count <= 3
+
+
+def _looks_like_latin_title(title):
+    words = re.findall(r"[A-Za-z]+", title)
+    if not words:
+        return False
+    if _LONG_LATIN_NOISE_PATTERN.search(title):
+        return False
+
+    lowercase_count = sum(1 for char in title if char.islower())
+    if lowercase_count:
+        return len(title) <= 80
+
+    if len(words) == 1:
+        return len(words[0]) >= 4
+    if len(words) > 2:
+        return False
+    if max(len(word) for word in words) < 7:
+        return False
+    return True
+
+
+def _should_keep_latin_token(token, previous_token="", next_token=""):
+    normalized = re.sub(r"[^A-Za-z0-9-]+", "", token)
+    if not normalized:
+        return True
+    if _is_heading_number(token):
+        return True
+    if not re.search(r"[A-Za-z]", normalized):
+        return True
+
+    letters = re.sub(r"[^A-Za-z]+", "", normalized)
+    if letters.isupper() and len(letters) == 1:
+        return bool(re.search(r"第\s*\d+\s*章", previous_token))
+    if letters.isupper() and 2 <= len(letters) <= 12:
+        return True
+
+    adjacent_to_cjk = _has_cjk(previous_token) or _has_cjk(next_token)
+    return adjacent_to_cjk and _looks_like_regular_latin_word(token)
+
+
+def _clean_embedded_latin_noise(token):
+    if not re.search(r"[\u4e00-\u9fff]", token):
+        return token
+    token = re.sub(r"^[0-9a-z]{3,}([\u4e00-\u9fff].*)$", r"\1", token)
+    return re.sub(
+        r"([\u4e00-\u9fff])([A-Za-z0-9'’<>{}\[\]_/|\\:;,.`~]{2,}.*)$",
+        r"\1",
+        token,
+    )
+
+
+def _clean_mixed_title_tokens(title):
+    raw_tokens = title.split()
+    tokens = []
+    for index, token in enumerate(raw_tokens):
+        token = _clean_embedded_latin_noise(token)
+        if not token:
+            continue
+        if _has_cjk(token):
+            tokens.append(token)
+            continue
+        previous_token = raw_tokens[index - 1] if index > 0 else ""
+        next_token = raw_tokens[index + 1] if index + 1 < len(raw_tokens) else ""
+        if _should_keep_latin_token(token, previous_token, next_token):
+            tokens.append(token)
+    return " ".join(tokens)
+
+
+def _clean_title_noise(title):
+    title = _clean_mixed_title_tokens(title)
+    title = re.sub(r"[\s.\-·•…_]+$", "", title.strip())
+    title = re.sub(r"\s+(?:和|站|ee|to|of)+$", "", title, flags=re.IGNORECASE)
+    if re.search(r"[\u4e00-\u9fff]", title):
+        match = list(re.finditer(r"[\u4e00-\u9fff]", title))
+        if match:
+            last_cjk_end = match[-1].end()
+            suffix = title[last_cjk_end:]
+            if len(re.findall(r"[A-Za-z]", suffix)) >= 4 and not _has_cjk(suffix):
+                title = title[:last_cjk_end]
+            if len(suffix) >= 5 and re.match(r"^[A-Za-z0-9\s.\-·•…_,;'\"`]+$", suffix):
+                title = title[:last_cjk_end]
+    return title.strip()
+
+
+def _is_toc_line(line):
+    cleaned = _clean_toc_line(line)
+    if len(cleaned) < 3:
+        return False
+    if not _TOC_LINE_PATTERN.match(cleaned):
+        return False
+
+    match = _TITLE_PAGE_PATTERN.match(cleaned)
+    if not match:
+        return False
+
+    title = match.group("title").strip()
+    title = _clean_title_noise(title)
+    if _SECTION_NUMBER_ONLY_PATTERN.match(title):
+        return False
+    if _NOISY_TITLE_PATTERN.search(title):
+        return False
+
+    title_chars = re.findall(r"[\u4e00-\u9fffA-Za-z]", title)
+    if len(title_chars) < 2:
+        return False
+    if not _has_cjk(title) and not _looks_like_latin_title(title):
+        return False
+
+    return True
+
+
+def _looks_like_toc_page(text):
+    normalized = normalize_page_text(text)
+    lines = [_clean_toc_line(line) for line in text.splitlines()]
+    toc_line_count = sum(1 for line in lines if _is_toc_line(line))
+    return "目录" in normalized or "contents" in normalized or toc_line_count >= 3
+
+
+def _extract_toc_lines_from_text(text):
+    return [entry[0] for entry in _extract_toc_entries_from_text(text)]
+
+
+def _extract_toc_entries_from_text(text):
+    page_entries = []
+    if not text:
+        return page_entries
+
+    seen = set()
+    for line in text.splitlines():
+        cleaned = _clean_toc_line(line)
+        if _is_toc_line(cleaned):
+            match = _TITLE_PAGE_PATTERN.match(cleaned)
+            title = _clean_title_noise(match.group("title"))
+            page_line = "{} {}".format(title, match.group("num"))
+            if page_line not in seen:
+                page_entries.append((page_line, True))
+                seen.add(page_line)
+
+    for line in _merge_wrapped_toc_lines(text):
+        cleaned = _clean_toc_line(line)
+        if _is_toc_line(cleaned):
+            match = _TITLE_PAGE_PATTERN.match(cleaned)
+            title = _clean_title_noise(match.group("title"))
+            page_line = "{} {}".format(title, match.group("num"))
+            if page_line not in seen:
+                page_entries.append((page_line, True))
+                seen.add(page_line)
+            continue
+
+        if _is_title_only_toc_line(cleaned):
+            page_line = _clean_title_noise(cleaned)
+            if page_line not in seen:
+                page_entries.append((page_line, False))
+                seen.add(page_line)
+    return _normalize_toc_entry_page_order(page_entries)
+
+
+def _split_toc_entry_page(line):
+    match = _TITLE_PAGE_PATTERN.match(_clean_toc_line(line))
+    if not match:
+        return line, None
+    return _clean_title_noise(match.group("title")), int(match.group("num"))
+
+
+def _normalize_toc_entry_page_order(
+    page_entries,
+    max_backward_gap=5,
+    max_forward_jump=500,
+):
+    normalized_entries = []
+    last_page_num = None
+    for index, (line, has_page) in enumerate(page_entries):
+        if not has_page:
+            normalized_entries.append((line, has_page))
+            continue
+
+        title, page_num = _split_toc_entry_page(line)
+        future_page_nums = [
+            _split_toc_entry_page(future_line)[1]
+            for future_line, future_has_page in page_entries[index + 1 :]
+            if future_has_page
+        ]
+        future_recovers = (
+            last_page_num is not None
+            and any(
+                num is not None and num + max_backward_gap >= last_page_num
+                for num in future_page_nums
+            )
+        )
+        suspicious_page = (
+            last_page_num is not None
+            and page_num is not None
+            and page_num + max_backward_gap < last_page_num
+            and (
+                future_recovers
+                or (page_num < 10 <= last_page_num)
+                or (
+                    _clean_title_noise(title).startswith("习题")
+                    and page_num < 10 <= last_page_num
+                )
+            )
+        )
+        suspicious_page = suspicious_page or (
+            last_page_num is not None
+            and page_num is not None
+            and page_num > last_page_num + max_forward_jump
+        )
+
+        if suspicious_page:
+            if _can_keep_toc_title_without_page(title):
+                normalized_entries.append((title, False))
+            continue
+
+        normalized_entries.append((line, has_page))
+        if page_num is not None:
+            last_page_num = page_num
+    return normalized_entries
+
+
+def extract_toc_text_from_page_texts(page_texts):
+    page_toc_entries = []
+    for text in page_texts:
+        page_toc_entries.append(_extract_toc_entries_from_text(text))
+
+    selected_lines = _select_toc_page_block(page_toc_entries)
+    return "\n".join(selected_lines)
+
+
+def _toc_entry_count(page_entries, require_page=False):
+    if require_page:
+        return sum(1 for _, has_page in page_entries if has_page)
+    return len(page_entries)
+
+
+def _is_strong_toc_page(page_entries, strong_threshold):
+    page_count = _toc_entry_count(page_entries, require_page=True)
+    return page_count >= strong_threshold or (
+        page_count >= 2 and _toc_entry_count(page_entries) >= strong_threshold
+    )
+
+
+def _select_toc_page_block(page_toc_entries, strong_threshold=3, tail_threshold=2):
+    best_start = None
+    best_end = None
+    best_score = 0
+    i = 0
+    while i < len(page_toc_entries):
+        if not _is_strong_toc_page(page_toc_entries[i], strong_threshold):
+            i += 1
+            continue
+
+        start = i
+        end = i + 1
+        score = _toc_entry_count(page_toc_entries[i], require_page=True)
+        saw_weak_tail = False
+        while end < len(page_toc_entries):
+            line_count = _toc_entry_count(page_toc_entries[end], require_page=True)
+            if line_count >= strong_threshold:
+                score += line_count
+                saw_weak_tail = False
+                end += 1
+                continue
+            if line_count >= tail_threshold and not saw_weak_tail:
+                score += line_count
+                saw_weak_tail = True
+                end += 1
+                continue
+            break
+
+        if score > best_score:
+            best_start = start
+            best_end = end
+            best_score = score
+        i = end
+
+    if best_start is None:
+        return []
+
+    selected = []
+    for page_entries in page_toc_entries[best_start:best_end]:
+        selected.extend(line for line, _ in page_entries)
+    return selected
+
+
+def _load_render_dependencies():
+    try:
+        import fitz
+        from PIL import Image
+    except ImportError as e:
+        raise OcrUnavailableError(
+            "OCR requires PyMuPDF and Pillow to render PDF pages"
+        ) from e
+    return fitz, Image
+
+
+def _load_paddleocr_dependencies(languages="ch"):
+    cache_root = os.path.join(sys.prefix, "paddle_cache")
+    os.environ.setdefault("XDG_CACHE_HOME", cache_root)
+    os.environ.setdefault("PADDLE_HOME", os.path.join(cache_root, "paddle"))
+    os.environ.setdefault(
+        "PADDLE_PDX_CACHE_HOME", os.path.join(cache_root, "paddlex")
+    )
+    os.environ.setdefault("PADDLE_PDX_ENABLE_MKLDNN_BYDEFAULT", "False")
+    os.environ.setdefault("FLAGS_use_mkldnn", "0")
+
+    try:
+        import numpy as np
+        from paddleocr import PaddleOCR
+    except ImportError as e:
+        raise OcrUnavailableError(
+            "PaddleOCR backend requires paddleocr and paddlepaddle"
+        ) from e
+
+    lang = _paddleocr_lang(languages)
+    try:
+        ocr = PaddleOCR(
+            lang=lang,
+            text_detection_model_name="PP-OCRv5_mobile_det",
+            text_recognition_model_name="PP-OCRv5_mobile_rec",
+            use_doc_orientation_classify=False,
+            use_doc_unwarping=False,
+            use_textline_orientation=False,
+            text_det_limit_side_len=1280,
+        )
+    except (TypeError, ValueError):
+        try:
+            ocr = PaddleOCR(lang=lang, use_textline_orientation=False)
+        except (TypeError, ValueError):
+            ocr = PaddleOCR(lang=lang)
+    return np, ocr
+
+
+def _paddleocr_lang(languages):
+    normalized = (languages or "").lower()
+    if "chi" in normalized or "ch" in normalized or "zh" in normalized:
+        return "ch"
+    if "eng" in normalized or "en" in normalized:
+        return "en"
+    return "ch"
+
+
+def _collect_paddleocr_texts(result):
+    texts = []
+
+    def collect(item):
+        if item is None:
+            return
+        if isinstance(item, dict):
+            for key in ("rec_texts", "texts"):
+                value = item.get(key)
+                if isinstance(value, list):
+                    texts.extend(str(text) for text in value if text)
+                    return
+            text = item.get("text")
+            if isinstance(text, str) and text:
+                texts.append(text)
+            return
+        if isinstance(item, tuple) and item and isinstance(item[0], str):
+            texts.append(item[0])
+            return
+        if isinstance(item, list):
+            if (
+                len(item) >= 2
+                and isinstance(item[1], (tuple, list))
+                and item[1]
+                and isinstance(item[1][0], str)
+            ):
+                texts.append(item[1][0])
+                return
+            for child in item:
+                collect(child)
+
+    collect(result)
+    return texts
+
+
+def _render_pdf_pages(pdf_path, max_pages, dpi):
+    fitz, Image = _load_render_dependencies()
+    scale = dpi / 72.0
+    matrix = fitz.Matrix(scale, scale)
+
+    document = fitz.open(pdf_path)
+    try:
+        page_count = min(len(document), max_pages)
+        for page_index in range(page_count):
+            page = document.load_page(page_index)
+            pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+            image = Image.open(BytesIO(pixmap.tobytes("png"))).convert("RGB")
+            yield page_index, page_count, image
+    finally:
+        document.close()
+
+
+def _paddleocr_image_to_text(ocr, np, image):
+    image_array = np.array(image)
+    if hasattr(ocr, "predict"):
+        result = ocr.predict(image_array)
+        return "\n".join(_collect_paddleocr_texts(result))
+
+    try:
+        result = ocr.ocr(image_array, cls=True)
+    except TypeError:
+        result = ocr.ocr(image_array)
+    except AttributeError:
+        result = ocr.predict(image_array)
+    return "\n".join(_collect_paddleocr_texts(result))
+
+
+def extract_toc_text_by_paddleocr(
+    pdf_path,
+    max_pages=30,
+    dpi=130,
+    languages="ch",
+    progress_callback=None,
+):
+    np, ocr = _load_paddleocr_dependencies(languages)
+    page_toc_entries = []
+    seen_toc_page = False
+    weak_pages_after_toc = 0
+
+    try:
+        for page_index, page_count, image in _render_pdf_pages(pdf_path, max_pages, dpi):
+            text = _paddleocr_image_to_text(ocr, np, image)
+            page_entries = _extract_toc_entries_from_text(text)
+            page_toc_entries.append(page_entries)
+            if progress_callback:
+                progress_callback(page_index + 1, page_count)
+
+            if _toc_entry_count(page_entries, require_page=True) >= 3:
+                seen_toc_page = True
+                weak_pages_after_toc = 0
+            elif seen_toc_page:
+                weak_pages_after_toc += 1
+                if weak_pages_after_toc >= 2:
+                    break
+    except Exception as e:
+        if isinstance(e, OcrUnavailableError):
+            raise
+        raise OcrUnavailableError("PaddleOCR page text failed: {}".format(e)) from e
+
+    return "\n".join(_select_toc_page_block(page_toc_entries))
+
+
+def extract_toc_text_by_tesseract(
+    pdf_path,
+    max_pages=30,
+    dpi=240,
+    languages="chi_sim+eng",
+    progress_callback=None,
+):
+    fitz, pytesseract, Image = _load_ocr_dependencies()
+    scale = dpi / 72.0
+    matrix = fitz.Matrix(scale, scale)
+    config = "{} --psm 4 -c preserve_interword_spaces=1".format(_tesseract_config())
+    page_texts = []
+
+    document = fitz.open(pdf_path)
+    try:
+        page_count = min(len(document), max_pages)
+        for page_index in range(page_count):
+            page = document.load_page(page_index)
+            pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+            image = Image.open(BytesIO(pixmap.tobytes("png")))
+            page_texts.append(
+                pytesseract.image_to_string(
+                    image, lang=languages, config=config
+                )
+            )
+            if progress_callback:
+                progress_callback(page_index + 1, page_count)
+    finally:
+        document.close()
+
+    return extract_toc_text_from_page_texts(page_texts)
+
+
+def extract_toc_text_by_ocr(
+    pdf_path,
+    max_pages=30,
+    dpi=130,
+    languages="ch",
+    progress_callback=None,
+    backend="paddle",
+    fallback_to_tesseract=True,
+):
+    if backend == "tesseract":
+        return extract_toc_text_by_tesseract(
+            pdf_path,
+            max_pages=max_pages,
+            dpi=240 if dpi == 220 else dpi,
+            languages="chi_sim+eng",
+            progress_callback=progress_callback,
+        )
+    if backend != "paddle":
+        raise ValueError("Unknown OCR backend: {}".format(backend))
+
+    try:
+        toc_text = extract_toc_text_by_paddleocr(
+            pdf_path,
+            max_pages=max_pages,
+            dpi=dpi,
+            languages=languages,
+            progress_callback=progress_callback,
+        )
+        if toc_text or not fallback_to_tesseract:
+            return toc_text
+    except OcrUnavailableError:
+        if not fallback_to_tesseract:
+            raise
+
+    return extract_toc_text_by_tesseract(
+        pdf_path,
+        max_pages=max_pages,
+        progress_callback=progress_callback,
+    )
+
+
+def extract_toc_text(
+    pdf_path,
+    max_pages=30,
+    use_ocr=True,
+    ocr_backend="paddle",
+    progress_callback=None,
+):
+    page_texts = extract_pdf_texts(pdf_path)[:max_pages]
+    toc_text = extract_toc_text_from_page_texts(page_texts)
+    if toc_text or not use_ocr:
+        return toc_text
+
+    return extract_toc_text_by_ocr(
+        pdf_path,
+        max_pages=max_pages,
+        backend=ocr_backend,
+        progress_callback=progress_callback,
+    )

--- a/src/pdf/toc.py
+++ b/src/pdf/toc.py
@@ -521,6 +521,17 @@ def _paddleocr_lang(languages):
     return "ch"
 
 
+def _tesseract_languages(languages):
+    normalized = (languages or "").strip().lower()
+    language_map = {
+        "ch": "chi_sim+eng",
+        "zh": "chi_sim+eng",
+        "zh-cn": "chi_sim+eng",
+        "en": "eng",
+    }
+    return language_map.get(normalized, languages or "chi_sim+eng")
+
+
 def _collect_paddleocr_texts(result):
     texts = []
 
@@ -691,7 +702,7 @@ def extract_toc_text_by_ocr(
             pdf_path,
             max_pages=max_pages,
             dpi=240 if dpi == 220 else dpi,
-            languages="chi_sim+eng",
+            languages=_tesseract_languages(languages),
             progress_callback=progress_callback,
             cancel_callback=cancel_callback,
             timeout=timeout,
@@ -717,6 +728,7 @@ def extract_toc_text_by_ocr(
     return extract_toc_text_by_tesseract(
         pdf_path,
         max_pages=max_pages,
+        languages=_tesseract_languages(languages),
         progress_callback=progress_callback,
         cancel_callback=cancel_callback,
         timeout=timeout,

--- a/tests/test_page_offset.py
+++ b/tests/test_page_offset.py
@@ -6,7 +6,10 @@ import src.pdf.page_offset as page_offset_module
 
 from src.pdf.page_offset import (
     OcrCancelledError,
+    _render_matrix,
+    _tesseract_config,
     extract_pdf_texts,
+    infer_page_offset_by_ocr,
     infer_page_offset_from_texts,
     normalize_page_text,
     page_contains_title,
@@ -99,6 +102,95 @@ def test_infer_page_offset_supports_negative_offsets():
     )
 
     assert offset == -9
+
+
+def test_infer_page_offset_rejects_equally_supported_offsets():
+    page_texts = [""] * 21
+    page_texts[9] = "Chapter One"
+    page_texts[10] = "Chapter Two"
+    page_texts[19] = "Chapter One"
+    page_texts[20] = "Chapter Two"
+
+    offset = infer_page_offset_from_texts(
+        "Chapter One 1\nChapter Two 2",
+        page_texts,
+    )
+
+    assert offset is None
+
+
+def test_tesseract_config_quotes_tessdata_path(monkeypatch):
+    monkeypatch.setattr(page_offset_module.sys, "prefix", "/tmp/Python Env")
+    monkeypatch.setattr(page_offset_module.os.path, "isdir", lambda path: True)
+
+    assert _tesseract_config() == '--tessdata-dir "/tmp/Python Env/tessdata"'
+
+
+def test_render_matrix_limits_oversized_pdf_pages():
+    class FakeRect(object):
+        width = 10_000
+        height = 10_000
+
+    class FakePage(object):
+        rect = FakeRect()
+
+    class FakeFitz(object):
+        Matrix = staticmethod(lambda x, y: (x, y))
+
+    matrix = _render_matrix(FakeFitz, FakePage(), dpi=240, max_pixels=1_000_000)
+
+    assert matrix[0] == pytest.approx(0.1)
+    assert matrix[1] == pytest.approx(0.1)
+
+
+def test_page_offset_ocr_skips_a_failed_page(monkeypatch):
+    texts = iter([RuntimeError("timeout"), "Chapter One", "Chapter Two"])
+
+    class FakePixmap(object):
+        def tobytes(self, image_format):
+            return b""
+
+    class FakePage(object):
+        def get_pixmap(self, matrix, alpha):
+            return FakePixmap()
+
+    class FakeDocument(object):
+        def __len__(self):
+            return 3
+
+        def load_page(self, page_index):
+            return FakePage()
+
+        def close(self):
+            pass
+
+    class FakeFitz(object):
+        Matrix = staticmethod(lambda x, y: object())
+        open = staticmethod(lambda pdf_path: FakeDocument())
+
+    class FakeTesseract(object):
+        def image_to_string(self, image, **kwargs):
+            result = next(texts)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    class FakeImage(object):
+        open = staticmethod(lambda data: object())
+
+    monkeypatch.setattr(
+        page_offset_module,
+        "_load_ocr_dependencies",
+        lambda: (FakeFitz, FakeTesseract(), FakeImage),
+    )
+
+    offset = infer_page_offset_by_ocr(
+        "book.pdf",
+        "Chapter One 1\nChapter Two 2",
+        max_pages=3,
+    )
+
+    assert offset == 1
 
 
 def test_extract_pdf_texts_respects_page_limit(monkeypatch, tmp_path):

--- a/tests/test_page_offset.py
+++ b/tests/test_page_offset.py
@@ -1,0 +1,82 @@
+# -*- coding:utf-8 -*-
+
+from src.pdf.page_offset import (
+    infer_page_offset_from_texts,
+    normalize_page_text,
+    page_contains_title,
+)
+
+
+def test_normalize_page_text_ignores_whitespace_and_case():
+    assert normalize_page_text("Chapter\n One") == "chapterone"
+
+
+def test_infer_page_offset_uses_consistent_title_matches():
+    page_texts = [""] * 50
+    page_texts[4] = "Contents\nChapter One 1\nChapter Two 20\nChapter Three 40"
+    page_texts[9] = "Chapter One\nBody text"
+    page_texts[28] = "Chapter Two\nBody text"
+    page_texts[48] = "Chapter Three\nBody text"
+
+    offset = infer_page_offset_from_texts(
+        "Chapter One 1\nChapter Two 20\nChapter Three 40",
+        page_texts,
+    )
+
+    assert offset == 9
+
+
+def test_infer_page_offset_ignores_contents_page_matches():
+    page_texts = [""] * 50
+    page_texts[4] = "Contents\nChapter One 1\nChapter Two 20\nChapter Three 40"
+    page_texts[9] = "Chapter One\nBody text"
+    page_texts[28] = "Chapter Two\nBody text"
+
+    offset = infer_page_offset_from_texts(
+        "Chapter One 1\nChapter Two 20\nChapter Three 40",
+        page_texts,
+    )
+
+    assert offset == 9
+
+
+def test_infer_page_offset_rejects_single_page_multi_title_match():
+    page_texts = ["Book Title\nBook Subtitle"]
+
+    offset = infer_page_offset_from_texts(
+        "Book Title 1\nBook Subtitle 1",
+        page_texts,
+    )
+
+    assert offset is None
+
+
+def test_infer_page_offset_returns_none_without_candidates():
+    assert infer_page_offset_from_texts("", ["Chapter One"]) is None
+
+
+def test_infer_page_offset_returns_none_for_ambiguous_single_match():
+    page_texts = ["Contents Chapter One 1", "Chapter One"]
+
+    assert infer_page_offset_from_texts("Chapter One 1", page_texts) is None
+
+
+def test_infer_page_offset_requires_multiple_candidates():
+    assert infer_page_offset_from_texts("Chapter One 1", ["Chapter One"]) is None
+
+
+def test_infer_page_offset_skips_title_only_toc_entries():
+    page_texts = ["Preface Chapter One Chapter Two"] + [""] * 30
+    page_texts[9] = "Section One"
+    page_texts[18] = "Section Two"
+
+    offset = infer_page_offset_from_texts(
+        "Chapter One\nChapter Two\nSection One 1\nSection Two 10",
+        page_texts,
+    )
+
+    assert offset == 9
+
+
+def test_page_contains_title_allows_ocr_noise():
+    assert page_contains_title("密码学原理与实践", "党码学原理与实践 第三版")

--- a/tests/test_page_offset.py
+++ b/tests/test_page_offset.py
@@ -1,6 +1,12 @@
 # -*- coding:utf-8 -*-
 
+import pytest
+
+import src.pdf.page_offset as page_offset_module
+
 from src.pdf.page_offset import (
+    OcrCancelledError,
+    extract_pdf_texts,
     infer_page_offset_from_texts,
     normalize_page_text,
     page_contains_title,
@@ -80,3 +86,48 @@ def test_infer_page_offset_skips_title_only_toc_entries():
 
 def test_page_contains_title_allows_ocr_noise():
     assert page_contains_title("密码学原理与实践", "党码学原理与实践 第三版")
+
+
+def test_infer_page_offset_supports_negative_offsets():
+    page_texts = [""] * 10
+    page_texts[0] = "Chapter Ten"
+    page_texts[9] = "Chapter Nineteen"
+
+    offset = infer_page_offset_from_texts(
+        "Chapter Ten 10\nChapter Nineteen 19",
+        page_texts,
+    )
+
+    assert offset == -9
+
+
+def test_extract_pdf_texts_respects_page_limit(monkeypatch, tmp_path):
+    class FakePage(object):
+        def __init__(self, text):
+            self.text = text
+
+        def extract_text(self):
+            return self.text
+
+    class FakeReader(object):
+        def __init__(self, handle, strict=False):
+            self.pages = [FakePage(str(index)) for index in range(5)]
+
+    monkeypatch.setattr(page_offset_module, "PdfReader", FakeReader)
+    pdf_path = tmp_path / "book.pdf"
+    pdf_path.write_bytes(b"pdf")
+
+    assert extract_pdf_texts(str(pdf_path), max_pages=2) == ["0", "1"]
+
+
+def test_extract_pdf_texts_can_be_cancelled(monkeypatch, tmp_path):
+    class FakeReader(object):
+        def __init__(self, handle, strict=False):
+            self.pages = [object()]
+
+    monkeypatch.setattr(page_offset_module, "PdfReader", FakeReader)
+    pdf_path = tmp_path / "book.pdf"
+    pdf_path.write_bytes(b"pdf")
+
+    with pytest.raises(OcrCancelledError):
+        extract_pdf_texts(str(pdf_path), cancel_callback=lambda: True)

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -1,5 +1,7 @@
 # -*- coding:utf-8 -*-
 
+import src.pdf.toc as toc_module
+
 from src.pdf.toc import extract_toc_text_from_page_texts
 
 
@@ -35,3 +37,60 @@ def test_extract_toc_text_ignores_non_contiguous_body_matches():
         "第1章 A 1\n第2章 B 2\n第3章 C 3\n第4章 D 4\n第5章 E 5\n"
         "第6章 F 6\n第7章 G 7"
     )
+
+
+def test_extract_toc_text_limits_text_layer_pages(monkeypatch):
+    call = {}
+
+    def fake_extract_pdf_texts(pdf_path, max_pages=None, cancel_callback=None):
+        call.update(pdf_path=pdf_path, max_pages=max_pages)
+        return []
+
+    monkeypatch.setattr(toc_module, "extract_pdf_texts", fake_extract_pdf_texts)
+
+    assert toc_module.extract_toc_text("book.pdf", max_pages=7, use_ocr=False) == ""
+    assert call == {"pdf_path": "book.pdf", "max_pages": 7}
+
+
+def test_tesseract_page_ocr_uses_timeout(monkeypatch):
+    calls = []
+
+    class FakePixmap(object):
+        def tobytes(self, image_format):
+            return b""
+
+    class FakePage(object):
+        def get_pixmap(self, matrix, alpha):
+            return FakePixmap()
+
+    class FakeDocument(object):
+        def __len__(self):
+            return 1
+
+        def load_page(self, page_index):
+            return FakePage()
+
+        def close(self):
+            pass
+
+    class FakeFitz(object):
+        Matrix = staticmethod(lambda x, y: object())
+        open = staticmethod(lambda pdf_path: FakeDocument())
+
+    class FakeTesseract(object):
+        def image_to_string(self, image, **kwargs):
+            calls.append(kwargs)
+            return ""
+
+    class FakeImage(object):
+        open = staticmethod(lambda data: object())
+
+    monkeypatch.setattr(
+        toc_module,
+        "_load_ocr_dependencies",
+        lambda: (FakeFitz, FakeTesseract(), FakeImage),
+    )
+
+    toc_module.extract_toc_text_by_tesseract("book.pdf", max_pages=1, timeout=7)
+
+    assert calls[0]["timeout"] == 7

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -130,3 +130,52 @@ def test_tesseract_page_ocr_uses_timeout_and_skips_failed_page(monkeypatch):
     assert len(calls) == 2
     assert all(call["timeout"] == 7 for call in calls)
     assert toc_text == "第一章 开始 1\n第二章 结束 2"
+
+
+def test_extract_toc_text_by_ocr_passes_languages_to_tesseract(monkeypatch):
+    calls = []
+
+    def fake_tesseract(pdf_path, **kwargs):
+        calls.append(kwargs["languages"])
+        return "toc"
+
+    monkeypatch.setattr(
+        toc_module, "extract_toc_text_by_tesseract", fake_tesseract
+    )
+
+    assert (
+        toc_module.extract_toc_text_by_ocr(
+            "book.pdf", backend="tesseract", languages="en"
+        )
+        == "toc"
+    )
+    assert (
+        toc_module.extract_toc_text_by_ocr(
+            "book.pdf", backend="tesseract", languages="deu+eng"
+        )
+        == "toc"
+    )
+    assert calls == ["eng", "deu+eng"]
+
+
+def test_extract_toc_text_by_ocr_passes_languages_to_tesseract_fallback(
+    monkeypatch,
+):
+    calls = []
+
+    monkeypatch.setattr(
+        toc_module,
+        "extract_toc_text_by_paddleocr",
+        lambda *args, **kwargs: "",
+    )
+
+    def fake_tesseract(pdf_path, **kwargs):
+        calls.append(kwargs["languages"])
+        return "toc"
+
+    monkeypatch.setattr(
+        toc_module, "extract_toc_text_by_tesseract", fake_tesseract
+    )
+
+    assert toc_module.extract_toc_text_by_ocr("book.pdf", languages="ch") == "toc"
+    assert calls == ["chi_sim+eng"]

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -1,0 +1,37 @@
+# -*- coding:utf-8 -*-
+
+from src.pdf.toc import extract_toc_text_from_page_texts
+
+
+def test_extract_toc_text_from_page_texts():
+    page_texts = [
+        "Cover",
+        (
+            "目录\n第1章 古典密码学 ........ 1\n第2章 分组密码 …… 42\n"
+            "附录A 参考资料 420\n1.1\nISBN 978-7-121-27971-3\n"
+            "ex (x) =(x+ K)mod 26"
+        ),
+        (
+            "第3章 Hash函数 ........ 92\n第4章 公钥密码 ........ 126\n"
+            "第5章 签名方案 ........ 222"
+        ),
+        "第1章 古典密码学\n正文",
+    ]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "第1章 古典密码学 1\n第2章 分组密码 42\n附录A 参考资料 420\n"
+        "第3章 Hash函数 92\n第4章 公钥密码 126\n第5章 签名方案 222"
+    )
+
+
+def test_extract_toc_text_ignores_non_contiguous_body_matches():
+    page_texts = [
+        "目录\n第1章 A 1\n第2章 B 2\n第3章 C 3\n第4章 D 4\n第5章 E 5",
+        "第6章 F 6\n第7章 G 7",
+        "正文\n第1章 A 1\n公式 2",
+    ]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "第1章 A 1\n第2章 B 2\n第3章 C 3\n第4章 D 4\n第5章 E 5\n"
+        "第6章 F 6\n第7章 G 7"
+    )

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -39,6 +39,36 @@ def test_extract_toc_text_ignores_non_contiguous_body_matches():
     )
 
 
+def test_extract_toc_text_accepts_small_explicit_contents_page():
+    page_texts = ["目录\n第一章 开始 1\n第二章 结束 2"]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "第一章 开始 1\n第二章 结束 2"
+    )
+
+
+def test_paddleocr_accepts_small_explicit_contents_page(monkeypatch):
+    monkeypatch.setattr(
+        toc_module,
+        "_load_paddleocr_dependencies",
+        lambda languages: (object(), object()),
+    )
+    monkeypatch.setattr(
+        toc_module,
+        "_render_pdf_pages",
+        lambda pdf_path, max_pages, dpi: iter([(0, 1, object())]),
+    )
+    monkeypatch.setattr(
+        toc_module,
+        "_paddleocr_image_to_text",
+        lambda ocr, np, image: "目录\n第一章 开始 1\n第二章 结束 2",
+    )
+
+    assert toc_module.extract_toc_text_by_paddleocr("book.pdf") == (
+        "第一章 开始 1\n第二章 结束 2"
+    )
+
+
 def test_extract_toc_text_limits_text_layer_pages(monkeypatch):
     call = {}
 
@@ -52,7 +82,7 @@ def test_extract_toc_text_limits_text_layer_pages(monkeypatch):
     assert call == {"pdf_path": "book.pdf", "max_pages": 7}
 
 
-def test_tesseract_page_ocr_uses_timeout(monkeypatch):
+def test_tesseract_page_ocr_uses_timeout_and_skips_failed_page(monkeypatch):
     calls = []
 
     class FakePixmap(object):
@@ -65,7 +95,7 @@ def test_tesseract_page_ocr_uses_timeout(monkeypatch):
 
     class FakeDocument(object):
         def __len__(self):
-            return 1
+            return 2
 
         def load_page(self, page_index):
             return FakePage()
@@ -80,7 +110,9 @@ def test_tesseract_page_ocr_uses_timeout(monkeypatch):
     class FakeTesseract(object):
         def image_to_string(self, image, **kwargs):
             calls.append(kwargs)
-            return ""
+            if len(calls) == 1:
+                raise RuntimeError("timeout")
+            return "目录\n第一章 开始 1\n第二章 结束 2"
 
     class FakeImage(object):
         open = staticmethod(lambda data: object())
@@ -91,6 +123,10 @@ def test_tesseract_page_ocr_uses_timeout(monkeypatch):
         lambda: (FakeFitz, FakeTesseract(), FakeImage),
     )
 
-    toc_module.extract_toc_text_by_tesseract("book.pdf", max_pages=1, timeout=7)
+    toc_text = toc_module.extract_toc_text_by_tesseract(
+        "book.pdf", max_pages=2, timeout=7
+    )
 
-    assert calls[0]["timeout"] == 7
+    assert len(calls) == 2
+    assert all(call["timeout"] == 7 for call in calls)
+    assert toc_text == "第一章 开始 1\n第二章 结束 2"

--- a/tests/test_toc_noise.py
+++ b/tests/test_toc_noise.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+
+from src.pdf.toc import _collect_paddleocr_texts, extract_toc_text_from_page_texts
+
+
+def test_extract_toc_text_removes_generic_ocr_latin_noise():
+    page_texts = [
+        (
+            "目录\n"
+            "3.3 线性密码分析TISCUNRTeACnbwelawemwenonances 61\n"
+            "3.3.3 SPN 的线性密码分析 66\n"
+            "4.2 Hash 函数的安全性 93\n"
+            "5.4.3 Miller-Rabin 算法 146\n"
+            "习题 S 54\n"
+            "12:2 FRAG BETES 22\n"
+            "6.5.5 TESA IBA HAG RAR 208\n"
+            "4.6 注释与参考文献cuNUaAUeaie 119\n"
+            "INTRODUCTION 1\n"
+            "DATA SECURITY 12\n"
+        )
+    ]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "3.3 线性密码分析 61\n"
+        "3.3.3 SPN 的线性密码分析 66\n"
+        "4.2 Hash 函数的安全性 93\n"
+        "5.4.3 Miller-Rabin 算法 146\n"
+        "习题 54\n"
+        "4.6 注释与参考文献 119\n"
+        "DATA SECURITY 12"
+    )
+
+
+def test_collect_paddleocr_texts_supports_common_result_shapes():
+    legacy_result = [
+        [
+            [[[0, 0], [1, 0], [1, 1], [0, 1]], ("第1章 古典密码学 1", 0.99)],
+            [[[0, 2], [1, 2], [1, 3], [0, 3]], ("1.1 引言 2", 0.98)],
+        ]
+    ]
+    dict_result = [{"rec_texts": ["第2章 分组密码 36", "2.1 引言 36"]}]
+
+    assert _collect_paddleocr_texts(legacy_result) == [
+        "第1章 古典密码学 1",
+        "1.1 引言 2",
+    ]
+    assert _collect_paddleocr_texts(dict_result) == [
+        "第2章 分组密码 36",
+        "2.1 引言 36",
+    ]
+
+
+def test_extract_toc_text_merges_paddleocr_wrapped_lines():
+    page_texts = [
+        (
+            "目录\n"
+            "作者简介\n"
+            "第1章\n"
+            "古典密码学\n"
+            "1.1.1\n"
+            "移位密码\n"
+            "1.1.2\n"
+            "代换密码\n"
+            ".5\n"
+            "1.1.3\n"
+            "仿射密码·\n"
+            "…6\n"
+            "3.3.3 SPN的线性密码分析\n"
+            "66\n"
+            "习题\n"
+            "…54\n"
+        )
+    ]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "第1章 古典密码学\n"
+        "1.1.1 移位密码\n"
+        "1.1.2 代换密码 5\n"
+        "1.1.3 仿射密码 6\n"
+        "3.3.3 SPN的线性密码分析 66\n"
+        "习题 54"
+    )
+
+
+def test_extract_toc_text_does_not_extend_block_with_title_only_body_page():
+    page_texts = [
+        (
+            "目录\n"
+            "第1章\n"
+            "古典密码学\n"
+            "1.1 引言\n"
+            "1\n"
+            "1.2 密码分析\n"
+            "19\n"
+            "1.3 注释与参考文献\n"
+            "29\n"
+        ),
+        (
+            "正文\n"
+            "第1章\n"
+            "古典密码学\n"
+            "1.1 引言\n"
+            "密码体制定义\n"
+            "1.2 密码分析\n"
+        ),
+    ]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "第1章 古典密码学\n"
+        "1.1 引言 1\n"
+        "1.2 密码分析 19\n"
+        "1.3 注释与参考文献 29"
+    )
+
+
+def test_extract_toc_text_drops_obviously_decreasing_page_numbers():
+    page_texts = [
+        (
+            "目录\n"
+            "3.2 代换-置换网络 58\n"
+            "3.3 线性密码分析 61\n"
+            "3.3.3 SPN的线性密码分析 66\n"
+            "3.4 差分密码分析 7\n"
+            "3.5 数据加密标准 74\n"
+            "习题 4\n"
+        )
+    ]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "3.2 代换-置换网络 58\n"
+        "3.3 线性密码分析 61\n"
+        "3.3.3 SPN的线性密码分析 66\n"
+        "3.4 差分密码分析\n"
+        "3.5 数据加密标准 74\n"
+        "习题"
+    )
+
+
+def test_extract_toc_text_drops_absurd_forward_page_jump():
+    page_texts = [
+        (
+            "目录\n"
+            "12.3 信任模型 356\n"
+            "12.4 PKI 的未来 361\n"
+            "14.2.1 利用 Ramp 方案的一种改进 6406\n"
+        )
+    ]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "12.3 信任模型 356\n"
+        "12.4 PKI 的未来 361\n"
+        "14.2.1 利用 Ramp 方案的一种改进"
+    )
+
+
+def test_extract_toc_text_drops_single_digit_page_after_large_page():
+    page_texts = [
+        (
+            "目录\n"
+            "3.3 线性密码分析 61\n"
+            "3.3.3 SPN的线性密码分析 66\n"
+            "3.4 差分密码分析 7\n"
+        )
+    ]
+
+    assert extract_toc_text_from_page_texts(page_texts) == (
+        "3.3 线性密码分析 61\n"
+        "3.3.3 SPN的线性密码分析 66\n"
+        "3.4 差分密码分析"
+    )

--- a/tests/test_toc_noise.py
+++ b/tests/test_toc_noise.py
@@ -50,6 +50,15 @@ def test_collect_paddleocr_texts_supports_common_result_shapes():
     ]
 
 
+def test_collect_paddleocr_texts_supports_paddleocr_3_result_shape():
+    result = [{"res": {"rec_texts": ["第1章 古典密码学 1", "1.1 引言 2"]}}]
+
+    assert _collect_paddleocr_texts(result) == [
+        "第1章 古典密码学 1",
+        "1.1 引言 2",
+    ]
+
+
 def test_extract_toc_text_merges_paddleocr_wrapped_lines():
     page_texts = [
         (

--- a/tests/test_toc_noise.py
+++ b/tests/test_toc_noise.py
@@ -1,6 +1,19 @@
 # -*- coding: utf-8 -*-
 
-from src.pdf.toc import _collect_paddleocr_texts, extract_toc_text_from_page_texts
+import os
+import sys
+import types
+
+import pytest
+
+import src.pdf.toc as toc_module
+
+from src.pdf.page_offset import OcrUnavailableError
+from src.pdf.toc import (
+    _collect_paddleocr_texts,
+    _load_paddleocr_dependencies,
+    extract_toc_text_from_page_texts,
+)
 
 
 def test_extract_toc_text_removes_generic_ocr_latin_noise():
@@ -57,6 +70,41 @@ def test_collect_paddleocr_texts_supports_paddleocr_3_result_shape():
         "第1章 古典密码学 1",
         "1.1 引言 2",
     ]
+
+
+def test_paddleocr_uses_user_cache_without_overriding_xdg_cache(
+    monkeypatch, tmp_path
+):
+    numpy_module = types.ModuleType("numpy")
+    paddleocr_module = types.ModuleType("paddleocr")
+    paddleocr_module.PaddleOCR = lambda **kwargs: object()
+    monkeypatch.setitem(sys.modules, "numpy", numpy_module)
+    monkeypatch.setitem(sys.modules, "paddleocr", paddleocr_module)
+    monkeypatch.setattr(toc_module.os, "environ", {"HOME": str(tmp_path)})
+
+    _load_paddleocr_dependencies()
+
+    assert "XDG_CACHE_HOME" not in os.environ
+    assert os.environ["PADDLE_HOME"] == str(tmp_path / ".cache/pdfdir/paddle")
+    assert os.environ["PADDLE_PDX_CACHE_HOME"] == str(
+        tmp_path / ".cache/pdfdir/paddlex"
+    )
+
+
+def test_paddleocr_initialization_failure_is_reported_as_unavailable(monkeypatch):
+    numpy_module = types.ModuleType("numpy")
+    paddleocr_module = types.ModuleType("paddleocr")
+
+    def fail_to_initialize(**kwargs):
+        raise RuntimeError("model download failed")
+
+    paddleocr_module.PaddleOCR = fail_to_initialize
+    monkeypatch.setitem(sys.modules, "numpy", numpy_module)
+    monkeypatch.setitem(sys.modules, "paddleocr", paddleocr_module)
+    monkeypatch.setattr(toc_module.os, "environ", {"HOME": "/tmp"})
+
+    with pytest.raises(OcrUnavailableError, match="Initialize PaddleOCR failed"):
+        _load_paddleocr_dependencies()
 
 
 def test_extract_toc_text_merges_paddleocr_wrapped_lines():

--- a/tests/test_toc_noise.py
+++ b/tests/test_toc_noise.py
@@ -12,6 +12,7 @@ from src.pdf.page_offset import OcrUnavailableError
 from src.pdf.toc import (
     _collect_paddleocr_texts,
     _load_paddleocr_dependencies,
+    _paddleocr_image_to_text,
     extract_toc_text_from_page_texts,
 )
 
@@ -70,6 +71,18 @@ def test_collect_paddleocr_texts_supports_paddleocr_3_result_shape():
         "第1章 古典密码学 1",
         "1.1 引言 2",
     ]
+
+
+def test_paddleocr_legacy_api_preserves_attribute_error():
+    class FakeNumpy(object):
+        array = staticmethod(lambda image: image)
+
+    class FakeOcr(object):
+        def ocr(self, image, cls=True):
+            raise AttributeError("model is not initialized")
+
+    with pytest.raises(AttributeError, match="model is not initialized"):
+        _paddleocr_image_to_text(FakeOcr(), FakeNumpy, object())
 
 
 def test_paddleocr_uses_user_cache_without_overriding_xdg_cache(


### PR DESCRIPTION
## Summary

This PR adds an "auto-fill page offset" workflow for PDF bookmark generation.

The new logic can infer the offset between printed TOC page numbers and actual PDF page positions by matching TOC titles against PDF page text.

## Changes

- Add page offset inference logic.
- Extract explicit TOC title/page-number candidates from directory text.
- Match TOC titles against PDF pages to calculate candidate offsets.
- Use repeated matches across multiple titles/pages to select a reliable offset.
- Skip TOC pages themselves to avoid false matches.
- Add OCR fallback for scanned PDFs.
- Run offset inference in a background Qt thread to avoid freezing the GUI.
- Add tests for offset inference and OCR-noise-tolerant title matching.

## Testing

```bash
pytest tests/test_page_offset.py -q